### PR TITLE
Fix link to documentation page

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can download previous versions of Karabiner-Elements from [here](https://pqr
 
 ## Usage
 
-<https://pqrs.org/osx/karabiner/document.html>
+<https://karabiner-elements.pqrs.org/docs/>
 
 ## Donations
 


### PR DESCRIPTION
Old documentation page doesn't work, I updated the link to my best bet on what the current docs site is.