### PR TITLE
Rewrite warning message

### DIFF
--- a/src/apps/PreferencesWindow/Resources/MainMenu.xib
+++ b/src/apps/PreferencesWindow/Resources/MainMenu.xib
@@ -1657,8 +1657,8 @@
                                                                             <rect key="frame" x="48" y="7" width="801" height="32"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="pcV-zf-cXs">
                                                                                 <font key="font" metaFont="menu"/>
-                                                                                <string key="title">Setting insufficient delay (e.g., 0) causes a device will become unusable after Karabiner-Elements is quitted due to macOS problem.
-(If you face the problem, you can solve it by unplugging the device and plugging it again.)</string>
+                                                                                <string key="title">Setting insufficient delay (e.g., 0) will result in a device becoming unusable after Karabiner-Elements is quit.
+(This is a macOS problem and can be solved by unplugging the device and plugging it again.)</string>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>


### PR DESCRIPTION
The warning message in `Prefs > Devices > Advanced > Delay before open device` had some grammatical issues making it difficult to grok what exactly the warning message was trying to convey so I rewrote the string
to be more clear.