### PR TITLE
Add touchpad enabling and unstickying of sticky modifiers

### DIFF
--- a/src/apps/PreferencesWindow/src/DevicesTableViewDelegate.m
+++ b/src/apps/PreferencesWindow/src/DevicesTableViewDelegate.m
@@ -34,10 +34,6 @@
     }
 
     result.checkbox.enabled = YES;
-    if (libkrbn_device_identifiers_is_apple(&deviceIdentifiers) &&
-        !deviceIdentifiers.is_keyboard) {
-      result.checkbox.enabled = NO;
-    }
 
     return result;
   }

--- a/src/core/grabber/include/grabber/device_grabber.hpp
+++ b/src/core/grabber/include/grabber/device_grabber.hpp
@@ -239,7 +239,8 @@ public:
           if (it != std::end(entries_)) {
             auto event_queue = event_queue::utility::make_queue(device_id,
                                                                 hid_queue_values_converter_.make_hid_values(device_id,
-                                                                                                            values_ptr));
+                                                                                                            values_ptr),
+                                                                is_built_in_pointing_device(it->second));
             event_queue = event_queue::utility::insert_device_keys_and_pointing_buttons_are_released_event(event_queue,
                                                                                                            device_id,
                                                                                                            it->second->get_pressed_keys_manager());

--- a/src/core/grabber/include/grabber/device_grabber_details/entry.hpp
+++ b/src/core/grabber/include/grabber/device_grabber_details/entry.hpp
@@ -153,6 +153,18 @@ public:
     }
   }
 
+  void async_start_queue_value_monitor_no_seize(void) {
+    if (hid_queue_value_monitor_) {
+      if (!hid_queue_value_monitor_async_start_called_) {
+        first_value_arrived_ = false;
+        hid_queue_value_monitor_async_start_called_ = true;
+      }
+
+      hid_queue_value_monitor_->async_start(kIOHIDOptionsTypeNone,
+                                            std::chrono::milliseconds(1000));
+    }
+  }
+
   void async_stop_queue_value_monitor(void) {
     if (hid_queue_value_monitor_) {
       hid_queue_value_monitor_async_start_called_ = false;

--- a/src/core/observer/include/observer/device_observer.hpp
+++ b/src/core/observer/include/observer/device_observer.hpp
@@ -59,7 +59,8 @@ public:
           hid_queue_value_monitor->values_arrived.connect([this, device_id](auto&& values_ptr) {
             auto event_queue = event_queue::utility::make_queue(device_id,
                                                                 hid_queue_values_converter_.make_hid_values(device_id,
-                                                                                                            values_ptr));
+                                                                                                            values_ptr),
+                                                                false);
             for (const auto& e : event_queue->get_entries()) {
               if (e.get_event().get_type() == event_queue::event::type::caps_lock_state_changed) {
                 if (auto client = grabber_client_.lock()) {
@@ -74,7 +75,8 @@ public:
           hid_queue_value_monitor->values_arrived.connect([this, device_id](auto&& values_ptr) {
             auto event_queue = event_queue::utility::make_queue(device_id,
                                                                 hid_queue_values_converter_.make_hid_values(device_id,
-                                                                                                            values_ptr));
+                                                                                                            values_ptr),
+                                                                false);
             for (const auto& entry : event_queue->get_entries()) {
               if (auto e = entry.get_event().template get_if<momentary_switch_event>()) {
                 if (auto client = grabber_client_.lock()) {

--- a/src/share/event_queue/queue.hpp
+++ b/src/share/event_queue/queue.hpp
@@ -70,7 +70,7 @@ public:
       }
 
       // Erase sticky modifiers
-      if (event_type == event_type::key_down &&
+      if ((event_type == event_type::key_down || event_type == event_type::single) &&
           validity == validity::valid &&
           !e->modifier_flag()) {
         modifier_flag_manager_.erase_all_sticky_modifier_flags();

--- a/src/share/event_queue/utility.hpp
+++ b/src/share/event_queue/utility.hpp
@@ -7,7 +7,8 @@ namespace krbn {
 namespace event_queue {
 namespace utility {
 static inline std::shared_ptr<queue> make_queue(device_id device_id,
-                                                const std::vector<pqrs::osx::iokit_hid_value>& hid_values) {
+                                                const std::vector<pqrs::osx::iokit_hid_value>& hid_values,
+                                                bool ignore) {
   auto result = std::make_shared<queue>();
 
   // The pointing motion usage (hid_usage::gd_x, hid_usage::gd_y, etc.) are splitted from one HID report.
@@ -22,10 +23,10 @@ static inline std::shared_ptr<queue> make_queue(device_id device_id,
   auto emplace_back_pointing_motion_event = [&] {
     if (pointing_motion_time_stamp) {
       pointing_motion pointing_motion(
-          pointing_motion_x ? *pointing_motion_x : 0,
-          pointing_motion_y ? *pointing_motion_y : 0,
-          pointing_motion_vertical_wheel ? *pointing_motion_vertical_wheel : 0,
-          pointing_motion_horizontal_wheel ? *pointing_motion_horizontal_wheel : 0);
+          pointing_motion_x && !ignore ? *pointing_motion_x : 0,
+          pointing_motion_y && !ignore ? *pointing_motion_y : 0,
+          pointing_motion_vertical_wheel && !ignore ? *pointing_motion_vertical_wheel : 0,
+          pointing_motion_horizontal_wheel && !ignore ? *pointing_motion_horizontal_wheel : 0);
 
       event_queue::event event(pointing_motion);
 

--- a/src/share/manipulator/manipulators/post_event_to_virtual_devices/post_event_to_virtual_devices.hpp
+++ b/src/share/manipulator/manipulators/post_event_to_virtual_devices/post_event_to_virtual_devices.hpp
@@ -200,7 +200,7 @@ public:
                                                       *mouse_key,
                                                       output_event_queue,
                                                       front_input_event.get_event_time_stamp().get_time_stamp());
-            } else {
+            } else if (front_input_event.get_event_type() == event_type::key_up) {
               mouse_key_handler_->erase_mouse_key(front_input_event.get_device_id(),
                                                   *mouse_key,
                                                   output_event_queue,


### PR DESCRIPTION
Fixes https://github.com/pqrs-org/Karabiner-Elements/issues/477#issuecomment-771694607#2997 

Issue: Touchpad cannot be enabled in Devices, to unstick sticky modifiers on click

This solution is pretty hacky, and overloads  `eventy_type::single` for mouse clicks. This fix allows the built in touchpad to be enabled for modification. When touchpad modification is enabled, it actually ignores virtual mouse key_up and key_down events, instead mapping them to `single` events which signal the sticky modifier to be disabled.

It will probably have to be refactored to be pulled in, but seems to be working, with no duplicate mouse clicks, and without affecting the native touchpad behavior.