### PR TITLE
Add multitouch upper quarter area count

### DIFF
--- a/src/apps/MultitouchExtension/src/AppDelegate.m
+++ b/src/apps/MultitouchExtension/src/AppDelegate.m
@@ -19,6 +19,7 @@ static void setGrabberVariable(FingerCount* count, bool sync) {
     int count;
     const char* name;
   } entries[] = {
+      {count.upperQuarterAreaCount, "multitouch_extension_finger_count_upper_quarter_area"},
       {count.upperHalfAreaCount, "multitouch_extension_finger_count_upper_half_area"},
       {count.lowerHalfAreaCount, "multitouch_extension_finger_count_lower_half_area"},
       {count.leftHalfAreaCount, "multitouch_extension_finger_count_left_half_area"},

--- a/src/apps/MultitouchExtension/src/FingerCount.h
+++ b/src/apps/MultitouchExtension/src/FingerCount.h
@@ -4,6 +4,7 @@
 
 @interface FingerCount : NSObject
 
+@property int upperQuarterAreaCount;
 @property int upperHalfAreaCount;
 @property int lowerHalfAreaCount;
 @property int leftHalfAreaCount;

--- a/src/apps/MultitouchExtension/src/FingerStatusManager.m
+++ b/src/apps/MultitouchExtension/src/FingerStatusManager.m
@@ -218,6 +218,9 @@
         ++fingerCount.lowerHalfAreaCount;
       } else {
         ++fingerCount.upperHalfAreaCount;
+        if (e.point.y > 0.75) {
+          ++fingerCount.upperQuarterAreaCount;
+        }
       }
 
       ++fingerCount.totalCount;


### PR DESCRIPTION
I recently added a rule using the multitouch extension and noticed I kept accidentally triggering it by resting a finger or two on the trackpad. For example, a common scenario I've experienced is when I'm using a browser with my right hand finger(s) on the center/bottom of the trackpad and decide to close the current tab by hitting cmd-w with my left hand.

To get around this, it'd be great to have a multitouch variable for just the upper quarter area where I'd normally touch/tap/click with my thumb to activate the multitouch rule.