### PR TITLE
Optimize the display of Complex Modifications view

### DIFF
--- a/src/apps/SettingsWindow/src/View/ComplexModificationsView.swift
+++ b/src/apps/SettingsWindow/src/View/ComplexModificationsView.swift
@@ -12,6 +12,27 @@ struct ComplexModificationsView: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 12.0) {
+      HStack {
+        Button(action: {
+          contentViewStates.complexModificationsViewSheetView = ComplexModificationsSheetView.assets
+          contentViewStates.complexModificationsViewSheetPresented = true
+        }) {
+          Label("Add rule", systemImage: "plus.circle.fill")
+        }
+
+        Spacer()
+
+        if settings.complexModificationsRules.count > 1 {
+          HStack {
+            Text("You can reorder list by dragging")
+            Image(systemName: "arrow.up.arrow.down.square.fill")
+                    .resizable(resizingMode: .stretch)
+                    .frame(width: 16.0, height: 16.0)
+            Text("icon")
+          }
+        }
+      }.padding([.leading, .trailing], 16)
+
       List {
         ForEach($settings.complexModificationsRules) { $complexModificationRule in
           VStack {
@@ -47,30 +68,8 @@ struct ComplexModificationsView: View {
             settings.moveComplexModificationsRule(first, destination)
           }
         }
-
-        Button(action: {
-          contentViewStates.complexModificationsViewSheetView = ComplexModificationsSheetView.assets
-          contentViewStates.complexModificationsViewSheetPresented = true
-        }) {
-          Label("Add rule", systemImage: "plus.circle.fill")
-        }
-        .if(settings.complexModificationsRules.count > 0) {
-          $0.padding(.top, 20.0)
-        }
       }
       .background(Color(NSColor.textBackgroundColor))
-
-      Spacer()
-
-      if settings.complexModificationsRules.count > 1 {
-        HStack {
-          Text("You can reorder list by dragging")
-          Image(systemName: "arrow.up.arrow.down.square.fill")
-            .resizable(resizingMode: .stretch)
-            .frame(width: 16.0, height: 16.0)
-          Text("icon")
-        }
-      }
     }
     .padding()
     .sheet(isPresented: $contentViewStates.complexModificationsViewSheetPresented) {


### PR DESCRIPTION
When the rule list items occupy the list, since the add rule button is displayed at the bottom of the list, when scrolling up the list, the add rule button may not be displayed. If you want to add rules, you have to scroll to the bottom of the list, which is very inconvenient. 

![image](https://user-images.githubusercontent.com/27394631/232656076-e43fd886-e47b-4188-8837-cc9d934b348b.png)

So I made two optimizations:

- The Add rule button in the Complex Modifications view is always displayed in the upper left corner.
- The sort hint text is displayed in the upper right corner to save display space.

The optimized interface is displayed as follows:

![image](https://user-images.githubusercontent.com/27394631/232656055-b526a818-9d07-4250-8594-71cfca7ee66e.png)