### PR TITLE
Run from.simultaneous_options.to_after_key_up despite halt option state in to derictives

### DIFF
--- a/src/share/manipulator/manipulators/basic/basic.hpp
+++ b/src/share/manipulator/manipulators/basic/basic.hpp
@@ -552,11 +552,16 @@ public:
                                                                        time_stamp_delay,
                                                                        *output_event_queue);
 
+                    bool was_halted = current_manipulated_original_event->get_halted();
+                    current_manipulated_original_event->set_halted(false); //reset halted, so we can use variables manipulation, as described in manual
+
                     event_sender::post_extra_to_events(front_input_event,
                                                        from_.get_simultaneous_options().get_to_after_key_up(),
                                                        *current_manipulated_original_event,
                                                        time_stamp_delay,
                                                        *output_event_queue);
+
+                    current_manipulated_original_event->set_halted(was_halted); //restore halted, in order not to affect latter logic
 
                     event_sender::post_from_mandatory_modifiers_key_down(front_input_event,
                                                                          *current_manipulated_original_event,

--- a/src/share/manipulator/manipulators/basic/event_sender.hpp
+++ b/src/share/manipulator/manipulators/basic/event_sender.hpp
@@ -171,9 +171,7 @@ inline void post_events_at_key_down(const event_queue::entry& front_input_event,
                                               event_queue::state::manipulated,
                                               it->get_lazy());
 
-        if (it->get_halt()) {
-          current_manipulated_original_event.set_halted();
-        }
+        current_manipulated_original_event.set_halted(it->get_halt());
       }
 
       // Post key_up event
@@ -282,9 +280,7 @@ inline void post_extra_to_events(const event_queue::entry& front_input_event,
                                               event_queue::state::manipulated,
                                               it->get_lazy());
 
-        if (it->get_halt()) {
-          current_manipulated_original_event.set_halted();
-        }
+        current_manipulated_original_event.set_halted(it->get_halt());
       }
 
       // Post key_up event

--- a/src/share/manipulator/manipulators/basic/manipulated_original_event/manipulated_original_event.hpp
+++ b/src/share/manipulator/manipulators/basic/manipulated_original_event/manipulated_original_event.hpp
@@ -47,8 +47,8 @@ public:
     return halted_;
   }
 
-  void set_halted(void) {
-    halted_ = true;
+  void set_halted(bool value) {
+    halted_ = value;
   }
 
   const events_at_key_up& get_events_at_key_up(void) const {


### PR DESCRIPTION
### Motivation
This simple patch allows to use any (space in my case) key as momentary layer switch while held down, and as a key itself if pressed short/alone

### The problem
[from.simultaneous_options](https://karabiner-elements.pqrs.org/docs/json/complex-modifications-manipulator-definition/from/simultaneous-options/#to_after_key_up) manual page states that `to_after_key_up` directive is typically used to clear mode flag variables when all from events are released. 

This is not an absolute case in current codebase. If `halt` option is set in any `to` directives, `from.simultaneous_options.to_after_key_up` will not fire, making `nav_layer` variable to stick with `1` value in the following scenario

```json
{
    "description": "Navigation layer",
    "manipulators": [
        {
            "from": {
                "modifiers": {
                    "optional": [
                        "any"
                    ]
                },
                "simultaneous": [
                    {
                        "key_code": "spacebar"
                    }
                ],
                "simultaneous_options": {
                    "detect_key_down_uninterruptedly": true,
                    "key_down_order": "insensitive",
                    "key_up_order": "insensitive",
                    "to_after_key_up": [
                        {
                            "set_variable": {
                                "name": "nav_layer",
                                "value": 0
                            }
                        },
                        {
                            "key_code": "vk_none",
                            "repeat": false
                        }
                    ]
                }
            },
            "parameters": {
                "basic.simultaneous_threshold_milliseconds": 1,
                "basic.to_if_held_down_threshold_milliseconds": 150
            },
            "to": [
                {
                    "set_variable": {
                        "name": "nav_layer",
                        "value": 1
                    }
                },
                {
                    "key_code": "vk_none",
                    "repeat": false
                }
            ],
            "to_after_key_up": [
                {
                    "set_variable": {
                        "name": "nav_layer",
                        "value": 0
                    }
                },
                {
                    "key_code": "vk_none",
                    "repeat": false
                }
            ],
            "to_if_alone": [
                {
                    "halt": true,
                    "key_code": "spacebar",
                    "repeat": false
                }
            ],
            "to_if_held_down": [
                {
                    "halt": true,
                    "key_code": "vk_none",
                    "repeat": false
                }
            ],
            "type": "basic"
        }
    ]
}
```

My entire keyboard config is located in [this repo](https://github.com/romansavrulin/karabiner-config).

Solution is tested for about a week and seems to be stable for me