### PR TITLE
Palm detection support

### DIFF
--- a/src/apps/MultitouchExtension/src/FingerCount.swift
+++ b/src/apps/MultitouchExtension/src/FingerCount.swift
@@ -8,4 +8,9 @@ struct FingerCount {
   var leftHalfAreaCount = 0
   var rightHalfAreaCount = 0
   var totalCount = 0
+  var upperHalfAreaPalmCount = 0
+  var lowerHalfAreaPalmCount = 0
+  var leftHalfAreaPalmCount = 0
+  var rightHalfAreaPalmCount = 0
+  var totalPalmCount = 0
 }

--- a/src/apps/MultitouchExtension/src/FingerManager.swift
+++ b/src/apps/MultitouchExtension/src/FingerManager.swift
@@ -68,15 +68,20 @@ class FingerManager: ObservableObject {
         }
       }
 
+      
 
       if s.touchedPhysically != touched || s.palmed != palmed {
+        if !s.palmed && !s.touchedPhysically {
+          s.setDelayTask(
+            mode: FingerState.DelayMode.touched)
+
+        }
+        else if !palmed && !touched {
+          s.setDelayTask(
+            mode: FingerState.DelayMode.untouched)
+        }
         s.palmed = palmed
         s.touchedPhysically = touched
-
-        s.setDelayTask(
-          mode: touched || palmed
-            ? FingerState.DelayMode.touched
-            : FingerState.DelayMode.untouched)
       }
     }
 
@@ -85,8 +90,9 @@ class FingerManager: ObservableObject {
     //
 
     for s in states {
-      if s.device == device && s.frame != frame && s.touchedPhysically {
+      if s.device == device && s.frame != frame && (s.touchedPhysically && !s.palmed) {
         s.touchedPhysically = false
+        s.palmed = false
 
         s.setDelayTask(mode: FingerState.DelayMode.untouched)
       }
@@ -124,47 +130,49 @@ class FingerManager: ObservableObject {
       }
 
       if s.touchedFixed {
-        if s.point.x < x50 {
-          fingerCount.leftHalfAreaCount += 1
-          if s.point.x < x25 {
-            fingerCount.leftQuarterAreaCount += 1
+        if s.touchedPhysically {
+          if s.point.x < x50 {
+            fingerCount.leftHalfAreaCount += 1
+            if s.point.x < x25 {
+              fingerCount.leftQuarterAreaCount += 1
+            }
+          } else {
+            fingerCount.rightHalfAreaCount += 1
+            if s.point.x > x75 {
+              fingerCount.rightQuarterAreaCount += 1
+            }
           }
-        } else {
-          fingerCount.rightHalfAreaCount += 1
-          if s.point.x > x75 {
-            fingerCount.rightQuarterAreaCount += 1
+
+          if s.point.y < y50 {
+            fingerCount.lowerHalfAreaCount += 1
+            if s.point.y < y25 {
+              fingerCount.lowerQuarterAreaCount += 1
+            }
+          } else {
+            fingerCount.upperHalfAreaCount += 1
+            if s.point.y > y75 {
+              fingerCount.upperQuarterAreaCount += 1
+            }
           }
+
+          fingerCount.totalCount += 1
         }
 
-        if s.point.y < y50 {
-          fingerCount.lowerHalfAreaCount += 1
-          if s.point.y < y25 {
-            fingerCount.lowerQuarterAreaCount += 1
+        if s.palmed {
+          if s.point.x < x50 {
+            fingerCount.leftHalfAreaPalmCount += 1
+          } else {
+            fingerCount.rightHalfAreaPalmCount += 1
           }
-        } else {
-          fingerCount.upperHalfAreaCount += 1
-          if s.point.y > y75 {
-            fingerCount.upperQuarterAreaCount += 1
+
+          if s.point.y < y50 {
+            fingerCount.lowerHalfAreaPalmCount += 1
+          } else {
+            fingerCount.upperHalfAreaPalmCount += 1
           }
+
+          fingerCount.totalPalmCount += 1
         }
-
-        fingerCount.totalCount += 1
-      }
-
-      if s.palmed {
-        if s.point.x < x50 {
-          fingerCount.leftHalfAreaPalmCount += 1
-        } else {
-          fingerCount.rightHalfAreaPalmCount += 1
-        }
-
-        if s.point.y < y50 {
-          fingerCount.lowerHalfAreaPalmCount += 1
-        } else {
-          fingerCount.upperHalfAreaPalmCount += 1
-        }
-
-        fingerCount.totalPalmCount += 1
       }
     }
 

--- a/src/apps/MultitouchExtension/src/FingerManager.swift
+++ b/src/apps/MultitouchExtension/src/FingerManager.swift
@@ -1,5 +1,4 @@
 import Combine
-import AppKit
 
 class FingerManager: ObservableObject {
   static let shared = FingerManager()
@@ -8,10 +7,8 @@ class FingerManager: ObservableObject {
   private(set) var states: [FingerState] = []
   // Task to reduce the frequency of calling objectWillChange.send
   private var objectWillChangeTask: Task<(), Never>?
-  private var hapticPerformer: NSHapticFeedbackPerformer
 
   init() {
-    hapticPerformer = NSHapticFeedbackManager.defaultPerformer
     NotificationCenter.default.addObserver(
       forName: FingerState.fingerStateChanged,
       object: nil,
@@ -72,21 +69,6 @@ class FingerManager: ObservableObject {
 
 
       if s.touchedPhysically != touched || s.palmed != palmed {
-        if s.palmed != palmed {
-          hapticPerformer.perform(
-            .levelChange,
-            performanceTime: .now
-            )
-          hapticPerformer.perform(
-            .generic,
-            performanceTime: .now
-            )
-          hapticPerformer.perform(
-            .alignment,
-            performanceTime: .now
-            )
-        }
-
         s.palmed = palmed
         s.touchedPhysically = touched
 

--- a/src/apps/MultitouchExtension/src/FingerManager.swift
+++ b/src/apps/MultitouchExtension/src/FingerManager.swift
@@ -55,6 +55,7 @@ class FingerManager: ObservableObject {
       let palmed = (Double(finger.size) > palmThreshold)
       let touched = (finger.state == 4 && !palmed)
       s.frame = Int(frame)
+      s.size = Double(finger.size)
       s.point = NSMakePoint(
         CGFloat(finger.normalized.position.x),
         CGFloat(finger.normalized.position.y))

--- a/src/apps/MultitouchExtension/src/FingerManager.swift
+++ b/src/apps/MultitouchExtension/src/FingerManager.swift
@@ -50,24 +50,12 @@ class FingerManager: ObservableObject {
     //
 
     for finger in fingers {
-      /**
-      print("frame: \(finger.frame)")
-      print("state: \(finger.state)")
-      print("normalized: \(finger.normalized)")
-      print("size: \(finger.size)")
-      print("pressure: \(finger.pressure)")
-      print("angle: \(finger.angle)")
-      print("absoluteVector: \(finger.absoluteVector)")
-      print("unknown1: \(finger.unknown1)")
-      print("density: \(finger.zDensity)")
-      **/
-      //print("pressure: \(finger.pressure), z: \(finger.zDensity), size: \(finger.size)")
       // state values:
       //   4: touched
       //   1-3,5-7: near
 
       let s = getFingerState(device: device, identifier: Int(finger.identifier))
-      let palmed = (finger.size > palmThreshold && finger.angle > 12)// || (s.touchedPhysically && s.palmed)
+      let palmed = (Double(finger.size) > palmThreshold)
       let touched = (finger.state == 4 && !palmed)
       s.frame = Int(frame)
       s.point = NSMakePoint(
@@ -84,10 +72,7 @@ class FingerManager: ObservableObject {
 
 
       if s.touchedPhysically != touched || s.palmed != palmed {
-        /**
-        if palmed {
-          print("Feedback \(palmed ? "Palmed" : "Unpalmed")")
-          
+        if s.palmed != palmed {
           hapticPerformer.perform(
             .levelChange,
             performanceTime: .now
@@ -101,7 +86,6 @@ class FingerManager: ObservableObject {
             performanceTime: .now
             )
         }
-        **/
 
         s.palmed = palmed
         s.touchedPhysically = touched

--- a/src/apps/MultitouchExtension/src/FingerState.swift
+++ b/src/apps/MultitouchExtension/src/FingerState.swift
@@ -18,6 +18,8 @@ class FingerState: Identifiable {
 
   var point = NSZeroPoint
 
+  var size = 0.0
+
   // True if the finger is touched physically.
   var touchedPhysically = false
 

--- a/src/apps/MultitouchExtension/src/FingerState.swift
+++ b/src/apps/MultitouchExtension/src/FingerState.swift
@@ -26,6 +26,9 @@ class FingerState: Identifiable {
 
   // True while the finger has never entered the valid area.
   var ignored = true
+  
+  // True if the palm is larger than the threshold
+  var palmed = false
 
   private var delayTask: Task<(), Never>?
 

--- a/src/apps/MultitouchExtension/src/MEGrabberClient.swift
+++ b/src/apps/MultitouchExtension/src/MEGrabberClient.swift
@@ -12,6 +12,11 @@ private class PreviousFingerCount {
   var leftHalfAreaCount = PreviousValue()
   var rightHalfAreaCount = PreviousValue()
   var totalCount = PreviousValue()
+  var upperHalfAreaPalmCount = PreviousValue()
+  var lowerHalfAreaPalmCount = PreviousValue()
+  var leftHalfAreaPalmCount = PreviousValue()
+  var rightHalfAreaPalmCount = PreviousValue()
+  var totalPalmCount = PreviousValue()
 }
 
 private var previousFingerCount = PreviousFingerCount()
@@ -68,6 +73,31 @@ private func staticSetGrabberVariable(_ count: FingerCount, _ sync: Bool) {
       name: "multitouch_extension_finger_count_total",
       value: count.totalCount,
       previousValue: previousFingerCount.totalCount
+    ),
+    GrabberVariable(
+      name: "multitouch_extension_palm_count_upper_half_area",
+      value: count.upperHalfAreaPalmCount,
+      previousValue: previousFingerCount.upperHalfAreaPalmCount
+    ),
+    GrabberVariable(
+      name: "multitouch_extension_palm_count_lower_half_area",
+      value: count.lowerHalfAreaPalmCount,
+      previousValue: previousFingerCount.lowerHalfAreaPalmCount
+    ),
+    GrabberVariable(
+      name: "multitouch_extension_palm_count_left_half_area",
+      value: count.leftHalfAreaPalmCount,
+      previousValue: previousFingerCount.leftHalfAreaPalmCount
+    ),
+    GrabberVariable(
+      name: "multitouch_extension_palm_count_right_half_area",
+      value: count.rightHalfAreaPalmCount,
+      previousValue: previousFingerCount.rightHalfAreaPalmCount
+    ),
+    GrabberVariable(
+      name: "multitouch_extension_palm_count_total",
+      value: count.totalPalmCount,
+      previousValue: previousFingerCount.totalPalmCount
     ),
   ] {
     if gv.previousValue.value != gv.value {

--- a/src/apps/MultitouchExtension/src/MultitouchPrivate.h
+++ b/src/apps/MultitouchExtension/src/MultitouchPrivate.h
@@ -18,7 +18,7 @@ typedef struct {
   int fingerId;
   int handId;
   mtReadout normalized;
-  float size;
+  double size;
   int pressure;
   float angle;
   float majorAxis;

--- a/src/apps/MultitouchExtension/src/MultitouchPrivate.h
+++ b/src/apps/MultitouchExtension/src/MultitouchPrivate.h
@@ -18,7 +18,7 @@ typedef struct {
   int fingerId;
   int handId;
   mtReadout normalized;
-  double size;
+  float size;
   int pressure;
   float angle;
   float majorAxis;

--- a/src/apps/MultitouchExtension/src/MultitouchPrivate.h
+++ b/src/apps/MultitouchExtension/src/MultitouchPrivate.h
@@ -15,17 +15,17 @@ typedef struct {
   double timestamp;
   int identifier;
   int state;
-  int unknown1;
-  int unknown2;
+  int fingerId;
+  int handId;
   mtReadout normalized;
   float size;
-  int unknown3;
+  int pressure;
   float angle;
   float majorAxis;
   float minorAxis;
-  mtReadout unknown4;
-  int unknown5[2];
-  float unknown6;
+  mtReadout absoluteVector;
+  int unknown1[2];
+  float zDensity;
 } Finger;
 
 typedef struct CF_BRIDGED_TYPE(id) MTDevice *MTDeviceRef;

--- a/src/apps/MultitouchExtension/src/UserSettings.swift
+++ b/src/apps/MultitouchExtension/src/UserSettings.swift
@@ -72,6 +72,13 @@ final class UserSettings: ObservableObject {
       objectWillChange.send()
     }
   }
+  
+  @UserDefault("kPalmThreshold", defaultValue: 13743898659100.75)
+  var palmThreshold: Double {
+    willSet {
+      objectWillChange.send()
+    }
+  }
 
   var targetArea: NSRect {
     let top = Double(ignoredAreaTop) / 100

--- a/src/apps/MultitouchExtension/src/UserSettings.swift
+++ b/src/apps/MultitouchExtension/src/UserSettings.swift
@@ -73,7 +73,7 @@ final class UserSettings: ObservableObject {
     }
   }
   
-  @UserDefault("kPalmThreshold", defaultValue: 13743898659100.75)
+  @UserDefault("kPalmThreshold", defaultValue: 2.0)
   var palmThreshold: Double {
     willSet {
       objectWillChange.send()

--- a/src/apps/MultitouchExtension/src/Views/Settings/FingerCountView.swift
+++ b/src/apps/MultitouchExtension/src/Views/Settings/FingerCountView.swift
@@ -31,6 +31,20 @@ struct FingerCountView: View {
         Text("right: \(fingerCount.rightQuarterAreaCount)").font(font)
       }
       .padding(.horizontal, 10.0)
+
+      VStack(alignment: .trailing) {
+        Text("palm-total")
+        Text("\(fingerCount.totalPalmCount)").font(font)
+      }
+      
+      VStack(alignment: .trailing) {
+        Text("palm-half")
+        Text("upper: \(fingerCount.upperHalfAreaPalmCount)").font(font)
+        Text("lower: \(fingerCount.lowerHalfAreaPalmCount)").font(font)
+        Text("left: \(fingerCount.leftHalfAreaPalmCount)").font(font)
+        Text("right: \(fingerCount.rightHalfAreaPalmCount)").font(font)
+      }
+      .padding(.horizontal, 10.0)
     }
   }
 }

--- a/src/apps/MultitouchExtension/src/Views/Settings/IgnoredAreaView.swift
+++ b/src/apps/MultitouchExtension/src/Views/Settings/IgnoredAreaView.swift
@@ -36,6 +36,7 @@ struct IgnoredAreaView: View {
             .fill(Color.gray.opacity(0.5))
             .frame(width: areaSize.width, height: areaSize.height)
 
+          let palmThreshold = userSettings.palmThreshold
           let targetArea = userSettings.targetArea
           let areaWidth = areaSize.width * targetArea.size.width
           let areaHeight = areaSize.height * targetArea.size.height
@@ -93,9 +94,13 @@ struct IgnoredAreaView: View {
               })
 
           ForEach(fingerManager.states) { state in
-            if state.touchedPhysically || state.touchedFixed {
-              let diameter = 10.0
-              let color = state.ignored ? Color.black : Color.red
+            if state.touchedPhysically || state.touchedFixed || state.palmed {
+              let minDiameter = 5.0
+              let thresholdDiameter = 15 + palmThreshold * 5
+              let palmed = state.size > palmThreshold
+              let diameter = minDiameter + (thresholdDiameter - minDiameter) * (state.size/palmThreshold)
+              let palmedColor = Color.purple
+              let color = state.ignored ? Color.black : (palmed ? palmedColor : Color.red)
               let leading = areaSize.width * state.point.x - (diameter / 2)
               let top = areaSize.height * (1.0 - state.point.y) - (diameter / 2)
 
@@ -112,6 +117,16 @@ struct IgnoredAreaView: View {
                   .padding(.leading, leading)
                   .padding(.top, top)
               }
+              let palmThresholdLeading = areaSize.width * state.point.x - (thresholdDiameter / 2)
+              let palmThresholdTop = areaSize.height * (1.0 - state.point.y) - (thresholdDiameter / 2)
+              VStack {
+              Circle()
+                .stroke(!state.touchedFixed ? Color.black : (palmed ? Color.gray : palmedColor), style: StrokeStyle(lineWidth: 2))
+                .frame(width: thresholdDiameter)
+              Text("\(String(format: "%.1f", state.size))")
+              }
+                .padding(.leading, palmThresholdLeading)
+                .padding(.top, palmThresholdTop)
             }
           }
         }

--- a/src/apps/MultitouchExtension/src/Views/Settings/SettingsAdvancedView.swift
+++ b/src/apps/MultitouchExtension/src/Views/Settings/SettingsAdvancedView.swift
@@ -81,6 +81,32 @@ struct SettingsAdvancedView: View {
       }
 
       Spacer()
+
+      GroupBox(label: Text("Palm Detection")) {
+        VStack(alignment: .leading, spacing: 30.0) {
+          VStack(alignment: .leading) {
+            HStack {
+              Text("Threshold:")
+
+              DoubleTextField(
+                value: $userSettings.palmThreshold,
+                range: 0...1000000000000000,
+                step: 100000000000000,
+                width: 80)
+
+              Text("size threshold (Default: 100000000000000)")
+
+              Spacer()
+            }
+
+            Text("(Increasing this value allows you to ignore unintended touch)")
+          }
+
+        }
+        .padding(6.0)
+      }
+
+      Spacer()
     }.padding()
   }
 }

--- a/src/apps/MultitouchExtension/src/Views/Settings/SettingsAdvancedView.swift
+++ b/src/apps/MultitouchExtension/src/Views/Settings/SettingsAdvancedView.swift
@@ -80,8 +80,6 @@ struct SettingsAdvancedView: View {
         .padding(6.0)
       }
 
-      Spacer()
-
       GroupBox(label: Text("Palm Detection")) {
         VStack(alignment: .leading, spacing: 30.0) {
           VStack(alignment: .leading) {
@@ -91,10 +89,10 @@ struct SettingsAdvancedView: View {
               DoubleTextField(
                 value: $userSettings.palmThreshold,
                 range: 0...10,
-                step: 1,
+                step: 0.5,
                 width: 80)
 
-              Text("palm threshold (Default: 2)")
+              Text("touch size threshold (Default: 2)")
 
               Spacer()
             }

--- a/src/apps/MultitouchExtension/src/Views/Settings/SettingsAdvancedView.swift
+++ b/src/apps/MultitouchExtension/src/Views/Settings/SettingsAdvancedView.swift
@@ -90,16 +90,16 @@ struct SettingsAdvancedView: View {
 
               DoubleTextField(
                 value: $userSettings.palmThreshold,
-                range: 0...1000000000000000,
-                step: 100000000000000,
+                range: 0...10,
+                step: 1,
                 width: 80)
 
-              Text("size threshold (Default: 100000000000000)")
+              Text("palm threshold (Default: 2)")
 
               Spacer()
             }
 
-            Text("(Increasing this value allows you to ignore unintended touch)")
+            Text("(Increasing this value allows you to ignore unintended palm touches)")
           }
 
         }

--- a/src/apps/share/swift/Views/DoubleTextField.swift
+++ b/src/apps/share/swift/Views/DoubleTextField.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+struct DoubleTextField: View {
+    @Binding var value: Double
+
+    private let step: Double
+    private let range: ClosedRange<Double>
+    private let width: CGFloat
+    private let formatter: NumberFormatter
+
+    init(
+        value: Binding<Double>,
+        range: ClosedRange<Double>,
+        step: Double,
+        width: CGFloat
+    ) {
+        _value = value
+        self.step = step
+        self.range = range
+        self.width = width
+
+        formatter = NumberFormatter()
+        formatter.numberStyle = .decimal // Use .decimal number style for double values
+        formatter.minimum = NSNumber(value: range.lowerBound)
+        formatter.maximum = NSNumber(value: range.upperBound)
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            TextField("", value: $value, formatter: formatter).frame(width: width)
+
+            Stepper(
+                value: $value,
+                in: range,
+                step: step
+            ) {
+                Text("")
+            }.whenHovered { hover in
+                if hover {
+                    // In macOS 13.0.1, if the corresponding TextField has the focus, changing the value by Stepper will not be reflected in the TextField.
+                    // Therefore, we should remove the focus before Stepper will be clicked.
+                    DispatchQueue.main.async {
+                        NSApp.keyWindow?.makeFirstResponder(nil)
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Got a chance to redo my changes with the swift refactor,  resolving #2698

This feature can help avoid inadvertent triggering of the fingers, but can also be used as an enhancement as it's own "key" to modulate behaviours and provide a new layer of keys.

Here's a demo with the IgnoredAreaView, including a new palmThreshold setting:

![Palm demo](https://github.com/pqrs-org/Karabiner-Elements/assets/10100843/d2b61de9-7370-40b8-a536-fcf38506e833)

Modifies the multitouch extension to add the following palm counts

I left out the quarterArea counts but maybe those would be useful?

```
upperHalfAreaPalmCount
lowerHalfAreaPalmCount
leftHalfAreaPalmCount
rightHalfAreaPalmCount
totalPalmCount
```

I didn't rename any of the multitouch extension stuff, which refers to all touch interactions as "fingers", as that would make rebasing more difficult if this doesn't get merged in, or takes a while to get merged in.

Introduces a new `palmThreshold` setting to configure how large of an area needs to be detected to be considered as a palm.

All palm events should respect ignore areas, as well as the touch detection. Release detection does not apply, since palm release should go right into finger detection.
