### PR TITLE
Explain why a keyboard would be ignored temporarily

### DIFF
--- a/src/core/grabber/include/grabber/device_grabber.hpp
+++ b/src/core/grabber/include/grabber/device_grabber.hpp
@@ -911,7 +911,10 @@ private:
 
     if (auto m = find_probable_stuck_events_manager(entry->get_device_id())) {
       if (auto event = m->find_probable_stuck_event()) {
-        auto message = fmt::format("{0} is ignored temporarily until {1} is pressed again.",
+        auto message = fmt::format("Probable stuck key detected! "
+                                   "{0} is ignored temporarily until {1} is pressed again. "
+                                   "Key may have been held when keyboard was grabbed. "
+                                   "Is the keyboard reconnecting while in use?",
                                    entry->get_device_name(),
                                    nlohmann::json(*event).dump());
         logger_unique_filter_.warn(message);
@@ -919,7 +922,8 @@ private:
         if (notification_message_manager_) {
           notification_message_manager_->async_set_device_ungrabbable_temporarily_message(
               entry->get_device_id(),
-              fmt::format("{0} is ignored temporarily until {1} is pressed again.",
+              fmt::format("Probable stuck key detected! "
+                          "{0} is ignored temporarily until {1} is pressed again.",
                           entry->get_device_short_name(),
                           nlohmann::json(*event).dump()));
         }


### PR DESCRIPTION
This should fix #3769 and hopefully reduce the number of lost people chiming in on #1848.

I'm not entirely sure I myself understand the meaning of a "probable stuck key" as detected by https://github.com/pqrs-org/Karabiner-Elements/blob/7b16957729b59587948a640578557696027a6413/src/share/probable_stuck_events_manager.hpp

I think it might mean "this key will probably get stuck if we grab the keyboard", and maybe not "this key is probably stuck on the device and the user should mash it until it seems to work properly". So I've worded the messages kind of vaguely.