### PR TITLE
Allow dictation to be remapped with Simple Modifications

### DIFF
--- a/src/apps/SettingsWindow/Resources/simple_modifications.json
+++ b/src/apps/SettingsWindow/Resources/simple_modifications.json
@@ -849,7 +849,6 @@
         ]
     },
     {
-        "not_from": true,
         "label": "dictation",
         "data": [
             {


### PR DESCRIPTION
Perhaps I'm being Chesterton's Fence'd here, but I don't see why the `dictation` button can't be remapped with simple_modifications. I just compiled it and tried it on my local machine, and it seems to work well. 

EDIT: I think this would also provide much easier/more effective workarounds for #2516 and #3123. I stumbled on this behavior because I tried to remap `dictation` (which is what pressing `f5` on an external keyboard shows as) via the `simple_modifications` UI. 