### PR TITLE
Add "Reset variables" button to Event Viewer Variables tab

### DIFF
--- a/src/apps/EventViewer/src/View/VariablesView.swift
+++ b/src/apps/EventViewer/src/View/VariablesView.swift
@@ -6,15 +6,25 @@ struct VariablesView: View {
   var body: some View {
     VStack(alignment: .leading, spacing: 0.0) {
       VStack(alignment: .leading, spacing: 12.0) {
-        Button(
-          action: {
-            let pboard = NSPasteboard.general
-            pboard.clearContents()
-            pboard.writeObjects([evCoreServiceClient.manipulatorEnvironmentStream.text as NSString])
-          },
-          label: {
-            Label("Copy to pasteboard", systemImage: "arrow.right.doc.on.clipboard")
-          })
+        HStack(alignment: .center, spacing: 12.0) {
+          Button(
+            action: {
+              let pboard = NSPasteboard.general
+              pboard.clearContents()
+              pboard.writeObjects([evCoreServiceClient.manipulatorEnvironmentStream.text as NSString])
+            },
+            label: {
+              Label("Copy to pasteboard", systemImage: "arrow.right.doc.on.clipboard")
+            })
+
+          Button(
+            action: {
+              resetVariables()
+            },
+            label: {
+              Label("Reset variables", systemImage: "arrow.counterclockwise")
+            })
+        }
       }
       .padding()
       .frame(maxWidth: .infinity, alignment: .leading)
@@ -35,6 +45,21 @@ struct VariablesView: View {
     }
     .onDisappear {
       evCoreServiceClient.manipulatorEnvironmentStop()
+    }
+  }
+
+  private func resetVariables() {
+    let jsonText = evCoreServiceClient.manipulatorEnvironmentStream.text
+
+    guard let jsonData = jsonText.data(using: .utf8),
+      let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+      let variables = json["variables"] as? [String: Any]
+    else {
+      return
+    }
+
+    for (name, _) in variables {
+      libkrbn_core_service_client_async_set_variable(name, Int32(0))
     }
   }
 }


### PR DESCRIPTION
First off - BIG THANKS for Karabiner-Elements! Without this tool I would literally be crying all day non-stop. God bless you for creating and maintaining this project. It's genuinely life-changing software.

## Summary

Adds a "Reset variables" button to the Variables tab in Event Viewer, allowing users to reset all variables to 0 (their default state) with a single click.

- Wraps existing "Copy to pasteboard" button in an HStack (following the pattern from `UnknownEventsView.swift`)
- Adds new "Reset variables" button with `arrow.counterclockwise` SF Symbol
- Parses current JSON from the manipulator environment stream to get variable names
- Calls `libkrbn_core_service_client_async_set_variable(name, 0)` for each variable

## Why

When testing complex modifications that set multiple variables, it's useful to quickly reset them all without restarting Karabiner or manually setting each one.

## Notes

- Follows existing codebase patterns exactly (HStack params, button styling, Int32 cast for API call)
- System variables like `system.now.milliseconds` will be immediately repopulated by the system
- Variables tab polls every 500ms, so changes appear almost immediately

---

If there are any adjustments needed - different approach, code style changes, naming conventions, or really anything at all - I would love to make any changes you suggest. Just let me know!