### PR TITLE
Add key 'ac_keyboard_layout_select'

### DIFF
--- a/src/apps/SettingsWindow/Resources/simple_modifications.json
+++ b/src/apps/SettingsWindow/Resources/simple_modifications.json
@@ -2950,6 +2950,11 @@
         "data": [{ "consumer_key_code": "ac_zoom_in" }]
     },
     {
+        "not_to": true,
+        "label": "ac_keyboard_layout_select",
+        "data": [{ "consumer_key_code": "ac_keyboard_layout_select" }]
+    },
+    {
         "category": "Remote control buttons"
     },
     {

--- a/src/share/types/momentary_switch_event_details/consumer_key_code.hpp
+++ b/src/share/types/momentary_switch_event_details/consumer_key_code.hpp
@@ -142,6 +142,7 @@ constexpr std::pair<const mapbox::eternal::string, const pqrs::hid::usage::value
     {"ac_zoom_out", pqrs::hid::usage::consumer::ac_zoom_out},
     {"ac_zoom_in", pqrs::hid::usage::consumer::ac_zoom_in},
     // Do not include ac_pan since it is used as mouse wheel, not button.
+    {"ac_keyboard_layout_select", pqrs::hid::usage::value_t(0x029d)},
 
     // Aliases
     {"fastforward", pqrs::hid::usage::consumer::fast_forward},


### PR DESCRIPTION
Adds support for key `ac_keyboard_layout_select` with HID usage ID `0x029D`.

This key is also known as "Globe key", without `fn` functionality.
This key is present on the Logitech Keys-to-Go 2 keyboard, which has VID `1133` and PID `45965`.

With support for this key, I can map it to a "standard" `fn` key and gain all the same functionality as an Apple keyboard.