### PR TITLE
Fix typo in ComplexModificationsView

### DIFF
--- a/src/apps/SettingsWindow/src/View/ComplexModificationsView.swift
+++ b/src/apps/SettingsWindow/src/View/ComplexModificationsView.swift
@@ -48,7 +48,7 @@ struct ComplexModificationsView: View {
 
         Spacer()
 
-        Label("For export", systemImage: "flame")
+        Label("For expert", systemImage: "flame")
 
         Button(
           action: {


### PR DESCRIPTION
The label on line 51 of `ComplexModificationsView.swift` reads "For export" but should read "For expert".

This is likely a typo. The flame icon `(systemImage: "flame")` used on this label is the same icon used for the Expert menu, which further suggests the intended text was "For expert" rather than "For export".