### PR TITLE
Invalidate the event tap CFMachPort on teardown

### DIFF
--- a/src/share/monitor/event_tap_monitor.hpp
+++ b/src/share/monitor/event_tap_monitor.hpp
@@ -85,6 +85,14 @@ public:
           run_loop_source_ = nullptr;
         }
 
+        // CoreGraphics keeps its own references to the CFMachPort returned by
+        // CGEventTapCreate, so releasing our reference never deallocates it.
+        // Without an explicit CFMachPortInvalidate, the window server keeps the
+        // (disabled) event tap registration until the process exits. These
+        // leaked registrations accumulate — one per event_tap_monitor teardown —
+        // and degrade system-wide input responsiveness once they number in the
+        // hundreds (see CGGetEventTapList).
+        CFMachPortInvalidate(event_tap_.get());
         event_tap_ = nullptr;
       }
 
@@ -164,6 +172,9 @@ public:
           } else {
             logger::get_logger()->error("event_tap_monitor failed to create run_loop_source");
 
+            // See async_stop: invalidation is required to release the window
+            // server registration; releasing the reference alone leaks it.
+            CFMachPortInvalidate(event_tap_.get());
             event_tap_ = nullptr;
           }
         } else {


### PR DESCRIPTION
This PR fixes a bug in Karabiner-Elements' event monitoring that seems to cause macOS to slow down over time, at least on macOS 26.5 and later. Here's a video demonstrating the issue; note how laggy mouse movements and menu updates are until I kill the Karabiner-Elements process:

https://github.com/user-attachments/assets/1cca3d8a-0821-4417-8557-1e77dab8f440

You can also find scripts to quickly reproduce the issue further down in this PR description.

Fixes #4498: the accumulating disabled CGEventTap registrations (and the WindowServer CPU/input-lag reports from the other users in that thread). The same leak also plausibly underlies the post-wake sluggishness reports in #4490 and #4478; those are already closed, so they're only referenced here.

This fix and analysis were prepared with AI assistance (Claude); all measurements and repro outputs below are from a real machine (macOS 26.5, Apple Silicon) and were reviewed by a human before filing. The PR description below was largely written by Claude but reviewed by me.

## Summary

`event_tap_monitor` tears its CGEventTap down with `CGEventTapEnable(false)` + `CFRunLoopRemoveSource` + releasing the `cf_ptr` references — but never calls `CFMachPortInvalidate`. CoreGraphics holds internal references to the `CFMachPort` returned by `CGEventTapCreate` (observed retain count 4 immediately after creation), so releasing the client reference never deallocates it, and **the window server keeps the (disabled) event-tap registration until the process exits**. Every `event_tap_monitor` teardown therefore leaks one stale registration.

Because teardowns are driven by console-user/session changes — including DarkWake maintenance cycles while the lid is closed — the long-lived Core Service daemon accumulates these entries continuously. On my machine (macOS 26.5, Karabiner-Elements 16.1.0): **953 stale disabled registrations in 6.2 days (~150/day)**, matching the 1,127 reported in #4498. At roughly 1,000 entries, system-wide input becomes noticeably sluggish (WindowServer's per-event tap-table processing scales with table size); killing the root daemon instantly reaps all its entries and restores responsiveness — which is exactly the "`sudo pkill` of the daemon fixes it, restarting the per-user agent doesn't" distinction reported in #4498, since the zombies are owned by the root daemon process.

This PR adds the missing `CFMachPortInvalidate` in `async_stop` and in the `async_start` error path that discards a freshly created tap when its run-loop source cannot be created.

## Why this is the missing piece even after v16.1.8

v16.1.8's change (shutting the receiver down completely during sleep) reduces how *often* teardown cycles happen, which helps a lot — but each remaining teardown (config reload, daytime IPC reconnects as in [WoojinAhn's report in #4498], device changes, residual sleep/wake cycles) still leaks one registration. With this fix, every teardown is clean regardless of its trigger, so the two changes complement each other.

## Mechanism verification (standalone, no Karabiner involved)

Verified on macOS 26.5 (Apple Silicon) with a minimal repro:

1. Create a listen-only HID tap, `CGEventTapEnable(false)`, remove the run-loop source, release all references — **the mach receive right stays alive and `CGGetEventTapList` keeps showing the entry** (disabled) indefinitely.
2. Same teardown but with `CFMachPortInvalidate` before the release — the entry is reaped from the tap table immediately (and the port name becomes invalid).
3. Repeating (1) in a loop grows the process's tap-table entry count by exactly 1 per cycle.
4. `CFGetRetainCount` on the freshly created tap port returns 4 — CoreGraphics' internal references are why a plain release can never trigger deallocation.

The same omission was found, confirmed, and fixed in Easydict ([tisfeng/Easydict#1170](https://github.com/tisfeng/Easydict/issues/1170)) with the same symptom profile (WindowServer main-thread saturation under high-frequency input, whole-system lag; ~25 leaked taps/hour there). Long-lived tap-heavy projects (Hammerspoon, LinearMouse) all call `CFMachPortInvalidate` in their teardown paths.

## Impact demonstration

Synthetically creating 1,000 disabled listen-only taps from a helper process (script below) makes input feel noticeably sluggish within seconds on an otherwise idle machine, and releasing them (or killing the process) restores it — i.e. the *count of stale disabled registrations alone* is sufficient to degrade input latency, independent of Karabiner.

Observed accumulation on my machine before/after bouncing the daemon (enumeration script below):

```
total taps: 1038
pid  12213  Karabiner-Core-Service  enabled=1 disabled=953    ← 6.2 days of daemon uptime
pid  11799  Mos                     enabled=5 disabled=55     ← same bug class in Mos
...
# sudo pkill -f Karabiner-Core-Service && re-run:
total taps: 84                                                 ← all reaped at process exit
```

Karabiner's own logs corroborate the per-teardown rate: `core_service.log` shows ~65 `event_tap_monitor initialized` lines per ~3 days (v16.1.0; each paired with a preceding teardown), concentrated around sleep/DarkWake windows in `pmset -g log`.

## Scripts

<details>
<summary><code>taplist.swift</code> — enumerate the window server tap table grouped by owning process (<code>swift taplist.swift</code>)</summary>

```swift
import AppKit
import CoreGraphics
import Darwin

var count: UInt32 = 0
CGGetEventTapList(0, nil, &count)
var taps = [CGEventTapInformation](repeating: CGEventTapInformation(), count: Int(count) + 16)
var actual: UInt32 = 0
let err = CGGetEventTapList(UInt32(taps.count), &taps, &actual)
taps = Array(taps.prefix(Int(actual)))

func processName(_ pid: pid_t) -> String {
    if let app = NSRunningApplication(processIdentifier: pid) { return app.localizedName ?? "pid\(pid)" }
    var buffer = [CChar](repeating: 0, count: 4096)
    if proc_name(pid, &buffer, UInt32(buffer.count)) > 0 { return String(cString: buffer) }
    // proc_name fails with EPERM for other users' (e.g. root) processes; sysctl works cross-user.
    var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, pid]
    var info = kinfo_proc()
    var size = MemoryLayout<kinfo_proc>.stride
    if sysctl(&mib, 4, &info, &size, nil, 0) == 0, size > 0, info.kp_proc.p_pid == pid {
        let name = withUnsafeBytes(of: info.kp_proc.p_comm) { raw in
            String(decoding: raw.prefix(while: { $0 != 0 }), as: UTF8.self)
        }
        if !name.isEmpty { return "\(name) (pid \(pid))" }
    }
    return "pid\(pid)(gone)"
}

print("total taps: \(actual) (err=\(err.rawValue))")
var byProcess: [pid_t: (name: String, enabled: Int, disabled: Int)] = [:]
for t in taps {
    var entry = byProcess[t.tappingProcess] ?? (processName(t.tappingProcess), 0, 0)
    if t.enabled { entry.enabled += 1 } else { entry.disabled += 1 }
    byProcess[t.tappingProcess] = entry
}
for (pid, entry) in byProcess.sorted(by: { ($0.value.enabled + $0.value.disabled) > ($1.value.enabled + $1.value.disabled) }) {
    print(String(format: "pid %6d  %-40@  enabled=%d disabled=%d", pid, entry.name as NSString, entry.enabled, entry.disabled))
}
```

</details>

<details>
<summary><code>bloatgen.swift</code> — demonstrate that N disabled registrations alone degrade input (<code>swift bloatgen.swift 1000 30</code>)</summary>

```swift
import AppKit
import CoreGraphics

// Creates N disabled listen-only taps (the exact server-side state the leak
// produces), holds them so system impact can be observed, then invalidates
// everything and exits. Process death reaps all entries — cannot leave residue.
// Usage: swift bloatgen.swift [count] [holdSeconds]

let count = CommandLine.arguments.count > 1 ? (Int(CommandLine.arguments[1]) ?? 1000) : 1000
let holdSeconds = CommandLine.arguments.count > 2 ? (Int(CommandLine.arguments[2]) ?? 30) : 30

func totalTaps() -> Int {
    var count: UInt32 = 0
    CGGetEventTapList(0, nil, &count)
    return Int(count)
}

let callback: CGEventTapCallBack = { _, _, event, _ in Unmanaged.passUnretained(event) }
let mask: CGEventMask =
    (1 << CGEventType.mouseMoved.rawValue)
    | (1 << CGEventType.leftMouseDown.rawValue)
    | (1 << CGEventType.leftMouseUp.rawValue)
    | (1 << CGEventType.rightMouseDown.rawValue)
    | (1 << CGEventType.rightMouseUp.rawValue)
    | (1 << CGEventType.leftMouseDragged.rawValue)
    | (1 << CGEventType.scrollWheel.rawValue)

setvbuf(stdout, nil, _IOLBF, 0)
let baseline = totalTaps()
print("baseline tap table: \(baseline) entries")

var held: [CFMachPort] = []
held.reserveCapacity(count)
for i in 0..<count {
    guard let tap = CGEvent.tapCreate(
        tap: .cghidEventTap, place: .tailAppendEventTap, options: .listenOnly,
        eventsOfInterest: mask, callback: callback, userInfo: nil)
    else {
        print("tapCreate FAILED at #\(i + 1) — holding the \(held.count) created so far")
        break
    }
    CGEvent.tapEnable(tap: tap, enable: false)
    held.append(tap)
}
print("created \(held.count) disabled taps — table now: \(totalTaps())")
NSSound.beep()
print("HOLDING for \(holdSeconds)s — wiggle the trackpad / drag windows and observe…")
for remaining in stride(from: holdSeconds, to: 0, by: -5) {
    print("  …\(remaining)s left (table: \(totalTaps()))")
    Thread.sleep(forTimeInterval: min(5, Double(remaining)))
}
for tap in held { CFMachPortInvalidate(tap) }
held.removeAll()
NSSound.beep()
print("released — table back to: \(totalTaps()) entries (baseline was \(baseline))")
```

Observed output on my machine:

```
baseline tap table: 84 entries
created 1000 disabled taps — table now: 1084
HOLDING for 30s — wiggle the trackpad / drag windows and observe…   ← clearly felt system-wide input lag
...
released — table back to: 84 entries (baseline was 84)
```

</details>

## Testing

- The mechanism (leak without invalidate / clean reap with it) is verified standalone as described above; the patched code path is identical in structure to the standalone repro's clean variant.
- Suggested verification on a patched build: run `taplist.swift` before/after several sleep-wake or config-reload cycles — the Core Service's disabled-entry count should stay at 0 instead of growing by 1 per cycle.
- The patched `Karabiner-Core-Service` target builds successfully (Release, `make` in `src/core/CoreService` with xcodegen + vendored CPM dependencies).
