### PR TITLE
Fix CGEventTap registration leak by invalidating the CFMachPort

### DIFF
--- a/src/share/monitor/event_tap_monitor.hpp
+++ b/src/share/monitor/event_tap_monitor.hpp
@@ -85,7 +85,7 @@ public:
           run_loop_source_ = nullptr;
         }
 
-        event_tap_ = nullptr;
+        invalidate_event_tap();
       }
 
       event_tap_cleanup_completed_ = true;
@@ -164,7 +164,7 @@ public:
           } else {
             logger::get_logger()->error("event_tap_monitor failed to create run_loop_source");
 
-            event_tap_ = nullptr;
+            invalidate_event_tap();
           }
         } else {
           logger::get_logger()->error("event_tap_monitor failed to create event tap (enable_cgeventtap_fallback={0})",
@@ -357,6 +357,27 @@ private:
     if (CGEventTapIsEnabled(event_tap_.get()) != enable) {
       logger::get_logger()->error("CGEventTapEnable failed ({0}, enable={1})", context, enable);
     }
+  }
+
+  // Releases event_tap_ and unregisters the EventTap.
+  // The caller must hold event_tap_mutex_.
+  //
+  // Note:
+  // Releasing our reference to the CFMachPort is not enough to unregister the EventTap.
+  // CGEventTapCreate returns a port that CoreGraphics keeps a reference to, and
+  // CFMachPortCreateRunLoopSource caches its run loop source inside the port while the
+  // source retains the port. The port's retain count therefore never reaches zero and the
+  // EventTap stays registered with the window server as a disabled entry. Since the window
+  // server walks the whole tap list for every input event, such leftover entries accumulate
+  // and add latency to all scrolling and typing system wide. CFMachPortInvalidate drops the
+  // remaining references and unregisters the EventTap.
+  void invalidate_event_tap() {
+    if (!event_tap_) {
+      return;
+    }
+
+    CFMachPortInvalidate(event_tap_.get());
+    event_tap_ = nullptr;
   }
 
   CGEventRef _Nullable callback(CGEventTapProxy _Nullable proxy, CGEventType type, CGEventRef _Nullable event) {


### PR DESCRIPTION
Fixes the CGEventTap registration leak reported in #4507.

## The bug

`event_tap_monitor` releases its `CFMachPortRef` without calling `CFMachPortInvalidate`, so the EventTap is never unregistered from the window server. Every `event_tap_monitor` teardown leaves one registration behind. Those registrations are disabled, but the window server still walks the whole tap list for each input event, so they accumulate into system wide scroll and typing latency that only restarting `Karabiner-Core-Service`, logging out or rebooting clears.

## Measured: releasing the port is not enough

A standalone program with no Karabiner involved, running the same create and teardown sequence as `event_tap_monitor::async_start` / `async_stop` 50 times and reading `CGGetEventTapList` before and after:

| teardown | taps before | taps after 50 cycles |
| --- | --- | --- |
| release only, as the current code does | 20 | 70 |
| release plus `CFMachPortInvalidate` | 20 | 20 |

Exactly one registration leaks per cycle. Retain counts from the same run: after `CFRelease` on the run loop source the port is still at 3, and `CFMachPortInvalidate` brings it to 1, so the `CFRelease` that follows finally deallocates it.

The error path in `async_start` leaks too. When no run loop source was ever created the port sits at 2 rather than 1, so `CFRelease` alone still does not unregister the tap, and 50 cycles took the list from 20 to 70 there as well. This PR covers both call sites.

<details>
<summary>Reproduction source</summary>

```c
// clang -o tap_leak_test tap_leak_test.c -framework ApplicationServices -framework CoreFoundation
// ./tap_leak_test     release only
// ./tap_leak_test i   release plus CFMachPortInvalidate

#include <ApplicationServices/ApplicationServices.h>
#include <stdio.h>

#define CYCLES 50

static CGEventRef callback(CGEventTapProxy proxy, CGEventType type, CGEventRef event, void *refcon) {
  return event;
}

static uint32_t tap_count(void) {
  uint32_t count = 0;
  CGGetEventTapList(0, NULL, &count);
  return count;
}

int main(int argc, char **argv) {
  int invalidate = (argc > 1 && argv[1][0] == 'i');

  printf("taps before: %u\n", tap_count());

  for (int i = 0; i < CYCLES; i++) {
    CFMachPortRef tap = CGEventTapCreate(kCGHIDEventTap,
                                         kCGTailAppendEventTap,
                                         kCGEventTapOptionListenOnly,
                                         CGEventMaskBit(kCGEventScrollWheel),
                                         callback,
                                         NULL);
    if (!tap) {
      printf("CGEventTapCreate failed (needs Input Monitoring)\n");
      return 1;
    }
    CFRunLoopSourceRef source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0);
    CFRunLoopAddSource(CFRunLoopGetCurrent(), source, kCFRunLoopCommonModes);
    CGEventTapEnable(tap, true);

    CGEventTapEnable(tap, false);
    CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, kCFRunLoopCommonModes);
    CFRelease(source);
    if (i == 0) {
      printf("  tap retain count after releasing the source: %ld\n", CFGetRetainCount(tap));
    }
    if (invalidate) {
      CFMachPortInvalidate(tap);
      if (i == 0) {
        printf("  tap retain count after CFMachPortInvalidate: %ld\n", CFGetRetainCount(tap));
      }
    }
    CFRelease(tap);
  }

  printf("taps after %d cycles: %u\n", CYCLES, tap_count());
  return 0;
}
```

</details>

## Measured: how it accumulates in practice

16.1.0 on macOS 26.5. Counted in `/var/log/karabiner/core_service*.log` over a window of 18 h 34 min:

| log line | count |
| --- | --- |
| `device_grabber is stopped.` | 335 |
| `event_tap_monitor terminated` | 333 |
| `setup_event_tap_monitor` | 332 |
| `Re-enable event_tap_` | 310 |

Each of those 333 teardowns leaked one registration, which is 17.9 per hour. After about three days of uptime `CGGetEventTapList` reported 1171 taps belonging to `Karabiner-Core-Service`, against a system total near 20 on a freshly booted machine. Killing the daemon took the total from 1191 to 20 and removed the lag immediately, which is what identified the source.

The 310 `Re-enable event_tap_` lines are `kCGEventTapDisabledByTimeout`. As the list grew, the system was disabling Karabiner's own tap because the callback no longer met the timeout, so the leak degraded the component that created it.

The stop and start cycle driving those teardowns comes from repeated `current_console_user_id` transitions, 667 lines in the same window, two per cycle with a chown to 0 and then back to 501. Whether that churn is expected is a separate question. This PR only makes each teardown clean, so the leak stops regardless of how often the monitor is recreated.

## Verification limits

I could not build and run a patched Karabiner-Elements end to end. The DriverKit extension requires `com.apple.developer.driverkit` and the individually authorized `com.apple.developer.driverkit.userclient-access`, and the Input Monitoring and Accessibility grants are tied to your code signature, so a self signed build cannot take over the real input path on a normal Mac.

Verified:

- The patched header compiles clean under `clang++ -std=c++23 -Wall -Werror -fsyntax-only` with the include paths from `tests.cmake`.
- The CoreFoundation behaviour the fix depends on, measured with the standalone program above.

Not verified:

- A runtime pass of the patched daemon. Please treat the runtime side accordingly.
