### PR TITLE
Support ELECOM HUGE Plus buttons 6-8

### DIFF
--- a/src/apps/CoreService/include/core_service/daemon/device_grabber_details/entry.hpp
+++ b/src/apps/CoreService/include/core_service/daemon/device_grabber_details/entry.hpp
@@ -11,6 +11,7 @@
 #include "pressed_keys_manager.hpp"
 #include "run_loop_thread_utility.hpp"
 #include "types.hpp"
+#include "undeclared_buttons_monitor.hpp"
 #include <pqrs/osx/iokit_hid_queue_value_monitor.hpp>
 
 namespace krbn::core_service::daemon::device_grabber_details {
@@ -49,6 +50,12 @@ public:
     hid_queue_value_monitor_->started.connect([this] {
       control_caps_lock_led_state_manager();
 
+      // Input reports are delivered only while the device is open, which the hid queue
+      // value monitor has just done.
+      if (undeclared_buttons_monitor_) {
+        undeclared_buttons_monitor_->async_start();
+      }
+
       if (seized()) {
         if (device_properties_->get_device_identifiers().get_is_game_pad()) {
           game_pad_stick_converter_ = std::make_unique<game_pad_stick_converter>(device_properties_,
@@ -65,6 +72,10 @@ public:
     });
     hid_queue_value_monitor_->stopped.connect([this] {
       control_caps_lock_led_state_manager();
+
+      if (undeclared_buttons_monitor_) {
+        undeclared_buttons_monitor_->async_stop();
+      }
 
       game_pad_stick_converter_ = nullptr;
     });
@@ -156,6 +167,35 @@ public:
       }
     });
 
+    //
+    // Buttons which the device reports but does not declare
+    //
+
+    undeclared_buttons_monitor_ = undeclared_buttons_monitor::make(
+        pqrs::dispatcher::extra::get_shared_dispatcher(),
+        pqrs::cf::run_loop_thread::extra::get_shared_run_loop_thread(),
+        device,
+        *device_properties_);
+
+    if (undeclared_buttons_monitor_) {
+      undeclared_buttons_monitor_->values_arrived.connect([this](auto&& values) {
+        // These values need none of the filtering the hid queue values above go through:
+        // they are always on pqrs::hid::usage_page::button, which "ignore_vendor_events"
+        // never matches, and no device we recover buttons for is the game pad that
+        // "filter_useless_events_from_specific_devices" targets. The pointing motion
+        // multipliers likewise do not apply to buttons.
+        auto event_queue_entries = event_queue::utility::make_entries(device_properties_,
+                                                                      *values,
+                                                                      {});
+
+        event_queue_entries = event_queue::utility::insert_device_keys_and_pointing_buttons_are_released_event(event_queue_entries,
+                                                                                                               device_id_,
+                                                                                                               pressed_keys_manager_);
+        hid_queue_values_arrived(*this,
+                                 event_queue_entries);
+      });
+    }
+
     device_name_ = iokit_utility::make_device_name_for_log(device_id,
                                                            device);
     device_short_name_ = iokit_utility::make_device_name(device);
@@ -163,7 +203,16 @@ public:
 
   ~entry() {
     detach_from_dispatcher([this] {
+      // The order matters: hid_queue_value_monitor_ owns the device being open, and
+      // undeclared_buttons_monitor_ owns the buffer IOKit copies input reports into. The
+      // device has to be closed before that buffer goes away, or reports arriving in
+      // between are written into freed memory.
+      //
+      // The start and stop paths are safe already, because iokit_hid_queue_value_monitor
+      // emits started() only after IOHIDDeviceOpen and stopped() only after
+      // IOHIDDeviceClose.
       hid_queue_value_monitor_ = nullptr;
+      undeclared_buttons_monitor_ = nullptr;
       game_pad_stick_converter_ = nullptr;
       caps_lock_led_state_manager_ = nullptr;
     });
@@ -337,6 +386,7 @@ private:
   pqrs::not_null_shared_ptr_t<pressed_keys_manager> pressed_keys_manager_;
   std::shared_ptr<hid_keyboard_caps_lock_led_state_manager> caps_lock_led_state_manager_;
   std::shared_ptr<pqrs::osx::iokit_hid_queue_value_monitor> hid_queue_value_monitor_;
+  std::shared_ptr<undeclared_buttons_monitor> undeclared_buttons_monitor_;
   std::unique_ptr<game_pad_stick_converter> game_pad_stick_converter_;
   hid_queue_values_converter hid_queue_values_converter_;
   std::string device_name_;

--- a/src/lib/libkrbn/include/libkrbn/impl/libkrbn_hid_value_monitor.hpp
+++ b/src/lib/libkrbn/include/libkrbn/impl/libkrbn_hid_value_monitor.hpp
@@ -3,6 +3,7 @@
 #include "event_queue.hpp"
 #include "libkrbn/libkrbn.h"
 #include "libkrbn_callback_manager.hpp"
+#include "undeclared_buttons_monitor.hpp"
 #include <atomic>
 #include <pqrs/gsl.hpp>
 #include <pqrs/osx/iokit_hid_manager.hpp>
@@ -73,6 +74,31 @@ public:
                          values_ptr);
         });
 
+        // Devices which under-declare their buttons need those buttons recovered from
+        // the raw input report, otherwise they are invisible here too and EventViewer
+        // shows nothing when they are pressed.
+        if (auto monitor = krbn::undeclared_buttons_monitor::make(
+                pqrs::dispatcher::extra::get_shared_dispatcher(),
+                pqrs::cf::run_loop_thread::extra::get_shared_run_loop_thread(),
+                *device_ptr,
+                *device_properties)) {
+          undeclared_buttons_monitors_.insert_or_assign(device_id, monitor);
+
+          monitor->values_arrived.connect([this, device_id, device_properties](auto&& values) {
+            handle_hid_values(device_id,
+                              device_properties,
+                              *values);
+          });
+
+          hid_queue_value_monitor->started.connect([monitor] {
+            monitor->async_start();
+          });
+
+          hid_queue_value_monitor->stopped.connect([monitor] {
+            monitor->async_stop();
+          });
+        }
+
         hid_queue_value_monitor->async_start(kIOHIDOptionsTypeNone,
                                              std::chrono::milliseconds(3000));
       }
@@ -81,7 +107,9 @@ public:
     hid_manager_->device_terminated.connect([this](auto&& registry_entry_id) {
       auto device_id = krbn::make_device_id(registry_entry_id);
 
+      // Closing the device has to come before releasing the report buffer.
       hid_queue_value_monitors_.erase(device_id);
+      undeclared_buttons_monitors_.erase(device_id);
 
       krbn::hat_switch_converter::get_global_hat_switch_converter()->erase_device(device_id);
     });
@@ -96,7 +124,10 @@ public:
   ~libkrbn_hid_value_monitor() {
     detach_from_dispatcher([this] {
       hid_manager_ = nullptr;
+      // Close the devices before releasing the buffers IOKit copies their input reports
+      // into. See the note in device_grabber_details::entry's destructor.
       hid_queue_value_monitors_.clear();
+      undeclared_buttons_monitors_.clear();
     });
   }
 
@@ -120,9 +151,20 @@ private:
   void values_arrived(krbn::device_id device_id,
                       pqrs::not_null_shared_ptr_t<krbn::device_properties> device_properties,
                       pqrs::not_null_shared_ptr_t<std::vector<pqrs::cf::cf_ptr<IOHIDValueRef>>> values) {
+    std::vector<pqrs::osx::iokit_hid_value> hid_values;
     for (const auto& value : *values) {
-      auto v = pqrs::osx::iokit_hid_value(*value);
+      hid_values.emplace_back(*value);
+    }
 
+    handle_hid_values(device_id,
+                      device_properties,
+                      hid_values);
+  }
+
+  void handle_hid_values(krbn::device_id device_id,
+                         pqrs::not_null_shared_ptr_t<krbn::device_properties> device_properties,
+                         const std::vector<pqrs::osx::iokit_hid_value>& values) {
+    for (const auto& v : values) {
       if (auto usage_page = v.get_usage_page()) {
         if (auto usage = v.get_usage()) {
           if (auto logical_max = v.get_logical_max()) {
@@ -147,6 +189,7 @@ private:
 
   std::unique_ptr<pqrs::osx::iokit_hid_manager> hid_manager_;
   std::unordered_map<krbn::device_id, pqrs::not_null_shared_ptr_t<pqrs::osx::iokit_hid_queue_value_monitor>> hid_queue_value_monitors_;
+  std::unordered_map<krbn::device_id, pqrs::not_null_shared_ptr_t<krbn::undeclared_buttons_monitor>> undeclared_buttons_monitors_;
   std::atomic<bool> observed_;
   libkrbn_callback_manager<libkrbn_hid_value_arrived_t> callback_manager_;
 };

--- a/src/share/undeclared_buttons.hpp
+++ b/src/share/undeclared_buttons.hpp
@@ -1,0 +1,126 @@
+#pragma once
+
+// Some ELECOM trackballs drive buttons in bits which their HID report descriptor
+// declares as constant padding. macOS creates no IOHIDElement for those bits, so they
+// have to be recovered from the raw input report.
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <pqrs/hid.hpp>
+#include <span>
+#include <vector>
+
+namespace krbn::undeclared_buttons {
+struct configuration final {
+  uint8_t report_id;
+  size_t buttons_byte_index;
+  uint8_t button_mask;
+};
+
+// Return the raw-report layout only when both the device id and the relevant part of its
+// descriptor match the known quirk. A changed descriptor must fall back to macOS rather
+// than risk emitting duplicate or incorrectly numbered buttons.
+[[nodiscard]] inline std::optional<configuration> find_configuration(
+    pqrs::hid::vendor_id::value_t vendor_id,
+    pqrs::hid::product_id::value_t product_id,
+    std::span<const uint8_t> report_descriptor) {
+  if (vendor_id != pqrs::hid::vendor_id::value_t(0x056e) ||
+      (product_id != pqrs::hid::product_id::value_t(0x01aa) &&
+       product_id != pqrs::hid::product_id::value_t(0x01ab) &&
+       product_id != pqrs::hid::product_id::value_t(0x01ac))) {
+    return std::nullopt;
+  }
+
+  // Mouse collection prefix from a real ELECOM HUGE PLUS (M-HT1MRBK, 056e:01aa).
+  // Buttons 1-5 occupy the low five bits of report 1; the firmware drives Fn1-Fn3 in
+  // the three constant bits immediately following them. Linux handles these same three
+  // product ids in drivers/hid/hid-elecom.c.
+  // clang-format off
+  constexpr std::array<uint8_t, 34> descriptor_prefix = {
+      0x05, 0x01, // Usage Page (Generic Desktop)
+      0x09, 0x02, // Usage (Mouse)
+      0xa1, 0x01, // Collection (Application)
+      0x85, 0x01, //   Report ID (1)
+      0x09, 0x01, //   Usage (Pointer)
+      0xa1, 0x00, //   Collection (Physical)
+      0x05, 0x09, //     Usage Page (Button)
+      0x19, 0x01, //     Usage Minimum (1)
+      0x29, 0x05, //     Usage Maximum (5)
+      0x15, 0x00, //     Logical Minimum (0)
+      0x25, 0x01, //     Logical Maximum (1)
+      0x75, 0x01, //     Report Size (1)
+      0x95, 0x05, //     Report Count (5)
+      0x81, 0x02, //     Input (Data,Var,Abs)
+      0x75, 0x03, //     Report Size (3)
+      0x95, 0x01, //     Report Count (1)
+      0x81, 0x01, //     Input (Cnst)
+  };
+  // clang-format on
+
+  if (report_descriptor.size() < descriptor_prefix.size() ||
+      !std::equal(std::begin(descriptor_prefix),
+                  std::end(descriptor_prefix),
+                  std::begin(report_descriptor))) {
+    return std::nullopt;
+  }
+
+  return configuration{
+      .report_id = 1,
+      .buttons_byte_index = 1, // Leading report id, then the button byte.
+      .button_mask = 0xe0,     // Buttons 6, 7 and 8.
+  };
+}
+
+struct button_change final {
+  uint8_t button;
+  bool pressed;
+
+  bool operator==(const button_change&) const = default;
+};
+
+class decoder final {
+public:
+  explicit decoder(const configuration& configuration)
+      : configuration_(configuration),
+        last_buttons_(0) {
+  }
+
+  [[nodiscard]] std::vector<button_change> update(uint8_t report_id,
+                                                  std::span<const uint8_t> report) {
+    std::vector<button_change> result;
+
+    if (report_id != configuration_.report_id ||
+        configuration_.buttons_byte_index >= report.size()) {
+      return result;
+    }
+
+    auto buttons = static_cast<uint8_t>(report[configuration_.buttons_byte_index] &
+                                        configuration_.button_mask);
+    auto changed = static_cast<uint8_t>(buttons ^ last_buttons_);
+    last_buttons_ = buttons;
+
+    for (uint8_t bit = 0; bit < 8; ++bit) {
+      auto mask = static_cast<uint8_t>(1u << bit);
+      if (changed & mask) {
+        result.push_back(button_change{
+            .button = static_cast<uint8_t>(bit + 1),
+            .pressed = (buttons & mask) != 0,
+        });
+      }
+    }
+
+    return result;
+  }
+
+  void reset() {
+    last_buttons_ = 0;
+  }
+
+private:
+  configuration configuration_;
+  uint8_t last_buttons_;
+};
+} // namespace krbn::undeclared_buttons

--- a/src/share/undeclared_buttons_monitor.hpp
+++ b/src/share/undeclared_buttons_monitor.hpp
@@ -1,0 +1,220 @@
+#pragma once
+
+#include "device_properties.hpp"
+#include "types.hpp"
+#include "undeclared_buttons.hpp"
+#include <mach/mach_time.h>
+#include <nod/nod.hpp>
+#include <pqrs/cf/run_loop_thread.hpp>
+#include <pqrs/dispatcher.hpp>
+#include <pqrs/gsl.hpp>
+#include <pqrs/osx/iokit_hid_device.hpp>
+#include <pqrs/osx/iokit_hid_value.hpp>
+#include <pqrs/thread_wait.hpp>
+#include <vector>
+
+namespace krbn {
+// Publishes the pointing buttons that krbn::undeclared_buttons recovers from a device's
+// raw input reports as ordinary HID values, so they flow through the rest of Karabiner as
+// regular pointing buttons.
+//
+// This class is the only part of the feature that touches IOKit; decoding stays in
+// undeclared_buttons.hpp so it can be tested without hardware.
+class undeclared_buttons_monitor final : public pqrs::dispatcher::extra::dispatcher_client {
+public:
+  //
+  // Signals (invoked from the shared dispatcher thread)
+  //
+
+  nod::signal<void(pqrs::not_null_shared_ptr_t<std::vector<pqrs::osx::iokit_hid_value>>)> values_arrived;
+
+  //
+  // Methods
+  //
+
+  undeclared_buttons_monitor(const undeclared_buttons_monitor&) = delete;
+
+  undeclared_buttons_monitor(std::weak_ptr<pqrs::dispatcher::dispatcher> weak_dispatcher,
+                             pqrs::not_null_shared_ptr_t<pqrs::cf::run_loop_thread> run_loop_thread,
+                             IOHIDDeviceRef device,
+                             const undeclared_buttons::configuration& configuration)
+      : dispatcher_client(weak_dispatcher),
+        run_loop_thread_(run_loop_thread),
+        hid_device_(device),
+        decoder_(configuration),
+        registered_(false) {
+    // IOHIDDeviceRegisterInputReportCallback writes into a buffer we own, so it has to be
+    // large enough for anything the device can send.
+    auto size = hid_device_.find_max_input_report_size().value_or(64);
+    if (size < 1) {
+      size = 64;
+    }
+    buffer_.resize(static_cast<size_t>(size));
+  }
+
+  ~undeclared_buttons_monitor() override {
+    detach_from_dispatcher();
+
+    // IOKit retains the report buffer even after the callback is cleared, so owners must
+    // close the IOHIDDevice before destroying this monitor. Synchronize the callback
+    // change here as well so no callback body remains in flight.
+    auto wait = pqrs::make_thread_wait();
+
+    run_loop_thread_->enqueue(^{
+      unregister_callback();
+
+      wait->notify();
+    });
+
+    wait->wait_notice();
+  }
+
+  // Build a monitor only for known devices with the expected report descriptor.
+  [[nodiscard]] static std::shared_ptr<undeclared_buttons_monitor> make(
+      std::weak_ptr<pqrs::dispatcher::dispatcher> weak_dispatcher,
+      pqrs::not_null_shared_ptr_t<pqrs::cf::run_loop_thread> run_loop_thread,
+      IOHIDDeviceRef device,
+      const device_properties& device_properties) {
+    const auto& identifiers = device_properties.get_device_identifiers();
+
+    // The spec describes the mouse collection's report, so it must not be applied to the
+    // keyboard or vendor-defined interfaces of the same physical device.
+    if (!identifiers.get_is_pointing_device()) {
+      return nullptr;
+    }
+
+    auto report_descriptor = find_report_descriptor(device);
+    auto configuration = undeclared_buttons::find_configuration(identifiers.get_vendor_id(),
+                                                                identifiers.get_product_id(),
+                                                                report_descriptor);
+    if (!configuration) {
+      return nullptr;
+    }
+
+    return std::make_shared<undeclared_buttons_monitor>(weak_dispatcher,
+                                                        run_loop_thread,
+                                                        device,
+                                                        *configuration);
+  }
+
+  void async_start() {
+    run_loop_thread_->enqueue(^{
+      if (registered_) {
+        return;
+      }
+
+      if (auto d = hid_device_.get_device()) {
+        IOHIDDeviceRegisterInputReportCallback(*d,
+                                               buffer_.data(),
+                                               static_cast<CFIndex>(buffer_.size()),
+                                               static_input_report_callback,
+                                               this);
+        registered_ = true;
+      }
+    });
+  }
+
+  void async_stop() {
+    run_loop_thread_->enqueue(^{
+      unregister_callback();
+    });
+  }
+
+private:
+  [[nodiscard]] static std::vector<uint8_t> find_report_descriptor(IOHIDDeviceRef device) {
+    std::vector<uint8_t> result;
+
+    if (auto property = IOHIDDeviceGetProperty(device, CFSTR(kIOHIDReportDescriptorKey))) {
+      if (CFGetTypeID(property) == CFDataGetTypeID()) {
+        auto data = static_cast<CFDataRef>(property);
+        auto length = CFDataGetLength(data);
+        if (length > 0) {
+          result.resize(static_cast<size_t>(length));
+          CFDataGetBytes(data, CFRangeMake(0, length), result.data());
+        }
+      }
+    }
+
+    return result;
+  }
+
+  // This method should be called in run_loop_thread_.
+  void unregister_callback() {
+    if (!registered_) {
+      return;
+    }
+
+    if (auto d = hid_device_.get_device()) {
+      IOHIDDeviceRegisterInputReportCallback(*d,
+                                             buffer_.data(),
+                                             static_cast<CFIndex>(buffer_.size()),
+                                             nullptr,
+                                             nullptr);
+    }
+
+    registered_ = false;
+    decoder_.reset();
+  }
+
+  static void static_input_report_callback(void* context,
+                                           IOReturn result,
+                                           void* sender,
+                                           IOHIDReportType type,
+                                           uint32_t report_id,
+                                           uint8_t* report,
+                                           CFIndex report_length) {
+    if (auto self = static_cast<undeclared_buttons_monitor*>(context)) {
+      self->input_report_callback(result,
+                                  type,
+                                  report_id,
+                                  report,
+                                  report_length);
+    }
+  }
+
+  // This method is called in run_loop_thread_.
+  void input_report_callback(IOReturn result,
+                             IOHIDReportType type,
+                             uint32_t report_id,
+                             uint8_t* report,
+                             CFIndex report_length) {
+    if (result != kIOReturnSuccess ||
+        type != kIOHIDReportTypeInput ||
+        report == nullptr ||
+        report_length < 0) {
+      return;
+    }
+
+    auto changes = decoder_.update(static_cast<uint8_t>(report_id),
+                                   std::span<const uint8_t>(report,
+                                                            static_cast<size_t>(report_length)));
+    if (changes.empty()) {
+      return;
+    }
+
+    auto time_stamp = pqrs::osx::chrono::absolute_time_point(mach_absolute_time());
+    auto values = std::make_shared<std::vector<pqrs::osx::iokit_hid_value>>();
+
+    for (const auto& c : changes) {
+      values->push_back(pqrs::osx::iokit_hid_value(time_stamp,
+                                                   c.pressed ? 1 : 0,
+                                                   pqrs::hid::usage_page::button,
+                                                   pqrs::hid::usage::value_t(c.button),
+                                                   1,
+                                                   0));
+    }
+
+    enqueue_to_dispatcher([this, values] {
+      values_arrived(values);
+    });
+  }
+
+  pqrs::not_null_shared_ptr_t<pqrs::cf::run_loop_thread> run_loop_thread_;
+  pqrs::osx::iokit_hid_device hid_device_;
+  std::vector<uint8_t> buffer_;
+
+  // The following are touched only in run_loop_thread_.
+  undeclared_buttons::decoder decoder_;
+  bool registered_;
+};
+} // namespace krbn

--- a/tests/src/undeclared_buttons/CMakeLists.txt
+++ b/tests/src/undeclared_buttons/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
+
+include (../../tests.cmake)
+
+project (karabiner_test)
+
+add_executable(
+  karabiner_test
+  src/test.cpp
+)

--- a/tests/src/undeclared_buttons/Makefile
+++ b/tests/src/undeclared_buttons/Makefile
@@ -1,0 +1,6 @@
+all: build_make
+	MallocNanoZone=0 ./build/karabiner_test
+
+clean: clean_builds
+
+include ../Makefile.rules

--- a/tests/src/undeclared_buttons/src/test.cpp
+++ b/tests/src/undeclared_buttons/src/test.cpp
@@ -1,0 +1,131 @@
+#include "undeclared_buttons.hpp"
+#include <boost/ut.hpp>
+
+namespace {
+using krbn::undeclared_buttons::button_change;
+
+std::vector<uint8_t> huge_plus_descriptor() {
+  // clang-format off
+  return {
+      0x05, 0x01, 0x09, 0x02, 0xa1, 0x01, 0x85, 0x01,
+      0x09, 0x01, 0xa1, 0x00, 0x05, 0x09, 0x19, 0x01,
+      0x29, 0x05, 0x15, 0x00, 0x25, 0x01, 0x75, 0x01,
+      0x95, 0x05, 0x81, 0x02, 0x75, 0x03, 0x95, 0x01,
+      0x81, 0x01, 0x05, 0x01, 0x09, 0x30, 0x09, 0x31,
+      0x16, 0x01, 0x80, 0x26, 0xff, 0x7f, 0x75, 0x10,
+      0x95, 0x02, 0x81, 0x06, 0xc0, 0xc0,
+  };
+  // clang-format on
+}
+
+std::optional<krbn::undeclared_buttons::configuration> huge_plus_configuration() {
+  return krbn::undeclared_buttons::find_configuration(
+      pqrs::hid::vendor_id::value_t(0x056e),
+      pqrs::hid::product_id::value_t(0x01aa),
+      huge_plus_descriptor());
+}
+
+krbn::undeclared_buttons::decoder huge_plus_decoder() {
+  return krbn::undeclared_buttons::decoder(*huge_plus_configuration());
+}
+
+std::vector<uint8_t> report(uint8_t buttons) {
+  return {0x01, buttons, 0x00, 0x00, 0x00, 0x00};
+}
+} // namespace
+
+int main() {
+  using namespace boost::ut;
+  using namespace boost::ut::literals;
+
+  "find known device configuration"_test = [] {
+    auto c = huge_plus_configuration();
+    expect(c != std::nullopt);
+    expect(c->report_id == 1_u);
+    expect(c->buttons_byte_index == 1_u);
+    expect(c->button_mask == 0xe0);
+
+    for (auto product_id : {
+             pqrs::hid::product_id::value_t(0x01aa),
+             pqrs::hid::product_id::value_t(0x01ab),
+             pqrs::hid::product_id::value_t(0x01ac),
+         }) {
+      expect(krbn::undeclared_buttons::find_configuration(
+                 pqrs::hid::vendor_id::value_t(0x056e),
+                 product_id,
+                 huge_plus_descriptor()) != std::nullopt);
+    }
+  };
+
+  "reject unknown device"_test = [] {
+    expect(krbn::undeclared_buttons::find_configuration(
+               pqrs::hid::vendor_id::value_t(0x056e),
+               pqrs::hid::product_id::value_t(0x0001),
+               huge_plus_descriptor()) == std::nullopt);
+    expect(krbn::undeclared_buttons::find_configuration(
+               pqrs::hid::vendor_id::value_t(0x05ac),
+               pqrs::hid::product_id::value_t(0x01aa),
+               huge_plus_descriptor()) == std::nullopt);
+  };
+
+  "reject changed descriptor"_test = [] {
+    auto descriptor = huge_plus_descriptor();
+    descriptor[17] = 0x08; // Firmware now declares all eight buttons.
+    expect(krbn::undeclared_buttons::find_configuration(
+               pqrs::hid::vendor_id::value_t(0x056e),
+               pqrs::hid::product_id::value_t(0x01aa),
+               descriptor) == std::nullopt);
+
+    descriptor = huge_plus_descriptor();
+    descriptor.resize(33);
+    expect(krbn::undeclared_buttons::find_configuration(
+               pqrs::hid::vendor_id::value_t(0x056e),
+               pqrs::hid::product_id::value_t(0x01aa),
+               descriptor) == std::nullopt);
+  };
+
+  "decode press, repeat and release"_test = [] {
+    auto decoder = huge_plus_decoder();
+
+    auto down = decoder.update(1, report(0x20));
+    expect(down == std::vector<button_change>{{.button = 6, .pressed = true}});
+    expect(decoder.update(1, report(0x20)).empty());
+
+    auto up = decoder.update(1, report(0x00));
+    expect(up == std::vector<button_change>{{.button = 6, .pressed = false}});
+  };
+
+  "decode recovered buttons only"_test = [] {
+    auto decoder = huge_plus_decoder();
+
+    // Declared button 1 is ignored; undeclared buttons 6 and 8 are reported.
+    auto changes = decoder.update(1, report(0xa1));
+    expect(changes == std::vector<button_change>{
+                          {.button = 6, .pressed = true},
+                          {.button = 8, .pressed = true},
+                      });
+
+    auto mixed = decoder.update(1, report(0x40));
+    expect(mixed == std::vector<button_change>{
+                        {.button = 6, .pressed = false},
+                        {.button = 7, .pressed = true},
+                        {.button = 8, .pressed = false},
+                    });
+  };
+
+  "ignore unrelated or short report"_test = [] {
+    auto decoder = huge_plus_decoder();
+    expect(decoder.update(2, std::vector<uint8_t>{0x02, 0xff}).empty());
+    expect(decoder.update(1, std::vector<uint8_t>{0x01}).empty());
+    expect(decoder.update(1, std::vector<uint8_t>{}).empty());
+  };
+
+  "reset decoder"_test = [] {
+    auto decoder = huge_plus_decoder();
+    expect(decoder.update(1, report(0x20)).size() == 1_u);
+    decoder.reset();
+    expect(decoder.update(1, report(0x20)).size() == 1_u);
+  };
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

The ELECOM HUGE Plus (M-HT1MRBK) declares only five mouse buttons in its HID report descriptor, but its firmware uses the following three padding bits for Fn1-Fn3. macOS does not create HID elements for bits declared as constant padding, so these buttons are invisible to both Karabiner-Elements and EventViewer.

This change reads those bits from the raw input report and exposes them as pointing buttons 6-8.

Support is restricted to ELECOM vendor ID `0x056e` and the HUGE Plus product IDs:

  - `0x01aa`: USB-C
  - `0x01ab`: 2.4 GHz receiver
  - `0x01ac`: Bluetooth

The workaround is enabled only when the relevant report descriptor prefix matches the known layout. This ensures that unrelated devices or changed firmware do not produce duplicate or incorrectly numbered events.

The raw-report monitor publishes recovered buttons through the existing HID value paths used by CoreService and EventViewer. The monitor and decoder are device-independent, allowing other affected devices to add their own strictly matched configuration later.

## Testing

- Installed and tested with an ELECOM HUGE Plus (`056e:01aa`); confirmed that Fn1-Fn3 can be observed and remapped as buttons 6-8.

<img width="345" height="194" alt="Pressing the Fn1, Fn2, and Fn3 buttons" src="https://github.com/user-attachments/assets/e64e4331-8383-4dae-85c1-e342d1530dd8" />

- `make -C tests/src/undeclared_buttons clean all` — 21 assertions across 7 tests passed.
- Karabiner-Core-Service universal Release build passed with code signing disabled.
- `libkrbn` universal Release build passed.
- Formatting, CMake inventory, and whitespace checks passed.

## Reference

The same HUGE Plus descriptor issue and its three connection-specific product IDs are documented in the Linux HID implementation:

  https://www.spinics.net/lists/kernel/msg6018993.html

This addresses the same Fn1-Fn3 detection limitation described in #3225, specifically for the newer ELECOM HUGE Plus hardware.

Related to #3225.