### PR TITLE
Add duration to notification messages

### DIFF
--- a/src/share/notification_message_manager.hpp
+++ b/src/share/notification_message_manager.hpp
@@ -4,9 +4,11 @@
 #include "modifier_flag_manager.hpp"
 #include "types/device_id.hpp"
 #include <map>
+#include <memory>
 #include <nod/nod.hpp>
 #include <pqrs/dispatcher.hpp>
 #include <sstream>
+#include <utility>
 
 // `krbn::notification_message_manager` can be used safely in a multi-threaded environment.
 
@@ -15,11 +17,16 @@ class notification_message_manager final : public pqrs::dispatcher::extra::dispa
 public:
   nod::signal<void(const std::string&)> notification_message_changed;
 
-  notification_message_manager()
-      : dispatcher_client() {
+  explicit notification_message_manager(std::weak_ptr<pqrs::dispatcher::dispatcher> weak_dispatcher =
+                                            pqrs::dispatcher::extra::get_shared_dispatcher())
+      : dispatcher_client(std::move(weak_dispatcher)) {
   }
 
   ~notification_message_manager() override {
+    for (auto& entry : expiration_tasks_) {
+      entry.second->cancel();
+    }
+
     detach_from_dispatcher();
   }
 
@@ -84,7 +91,29 @@ public:
 
   void async_set_notification_message(const notification_message& notification_message) {
     enqueue_to_dispatcher([this, notification_message] {
-      messages_[fmt::format("__user__{0}", notification_message.get_id())] = notification_message.get_text();
+      auto id = fmt::format("__user__{0}", notification_message.get_id());
+
+      messages_[id] = notification_message.get_text();
+
+      if (auto it = expiration_tasks_.find(id); it != std::end(expiration_tasks_)) {
+        it->second->cancel();
+      }
+
+      auto duration_milliseconds = notification_message.get_duration_milliseconds();
+      if (!notification_message.get_text().empty() &&
+          duration_milliseconds.count() > 0) {
+        auto& expiration_task = expiration_tasks_[id];
+        if (!expiration_task) {
+          expiration_task = std::make_unique<pqrs::dispatcher::extra::debounced_task>(*this);
+        }
+
+        expiration_task->debounce_after(
+            [this, id] {
+              messages_[id] = "";
+              update_full_message();
+            },
+            duration_milliseconds);
+      }
 
       update_full_message();
     });
@@ -111,6 +140,7 @@ private:
   }
 
   std::map<std::string, std::string> messages_;
+  std::map<std::string, std::unique_ptr<pqrs::dispatcher::extra::debounced_task>> expiration_tasks_;
   std::string full_message_;
 };
 } // namespace krbn

--- a/src/share/types/notification_message.hpp
+++ b/src/share/types/notification_message.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <pqrs/hash.hpp>
 #include <pqrs/json.hpp>
 
@@ -25,11 +26,20 @@ public:
     text_ = text;
   }
 
+  [[nodiscard]] std::chrono::milliseconds get_duration_milliseconds() const {
+    return duration_milliseconds_;
+  }
+
+  void set_duration_milliseconds(std::chrono::milliseconds value) {
+    duration_milliseconds_ = value;
+  }
+
   bool operator==(const notification_message&) const = default;
 
 private:
   std::string id_;
   std::string text_;
+  std::chrono::milliseconds duration_milliseconds_{0};
 };
 
 inline void to_json(nlohmann::json& json, const notification_message& value) {
@@ -37,6 +47,10 @@ inline void to_json(nlohmann::json& json, const notification_message& value) {
       {"id", value.get_id()},
       {"text", value.get_text()},
   });
+
+  if (value.get_duration_milliseconds().count() > 0) {
+    json["duration_milliseconds"] = value.get_duration_milliseconds().count();
+  }
 }
 
 inline void from_json(const nlohmann::json& json, notification_message& value) {
@@ -49,6 +63,17 @@ inline void from_json(const nlohmann::json& json, notification_message& value) {
     } else if (k == "text") {
       pqrs::json::requires_string(v, k);
       value.set_text(v.get<std::string>());
+    } else if (k == "duration_milliseconds") {
+      pqrs::json::requires_number(v, "`" + k + "`");
+
+      auto duration_milliseconds = v.get<int>();
+      if (duration_milliseconds < 0) {
+        throw pqrs::json::unmarshal_error(fmt::format("`{0}` must be greater than or equal to 0, but is `{1}`",
+                                                      k,
+                                                      duration_milliseconds));
+      }
+
+      value.set_duration_milliseconds(std::chrono::milliseconds(duration_milliseconds));
     } else {
       throw pqrs::json::unmarshal_error(fmt::format("unknown key: `{0}`", k));
     }
@@ -64,6 +89,7 @@ struct hash<krbn::notification_message> final {
 
     pqrs::hash::combine(h, value.get_id());
     pqrs::hash::combine(h, value.get_text());
+    pqrs::hash::combine(h, value.get_duration_milliseconds().count());
 
     return h;
   }

--- a/tests/src/manipulator_types/json/errors/event_definition_errors.jsonc
+++ b/tests/src/manipulator_types/json/errors/event_definition_errors.jsonc
@@ -252,6 +252,24 @@
         "class": "event_definition",
         "input": {
             "set_notification_message": {
+                "duration_milliseconds": null
+            }
+        },
+        "error": "`set_notification_message` error: `duration_milliseconds` must be number, but is `null`"
+    },
+    {
+        "class": "event_definition",
+        "input": {
+            "set_notification_message": {
+                "duration_milliseconds": -1
+            }
+        },
+        "error": "`set_notification_message` error: `duration_milliseconds` must be greater than or equal to 0, but is `-1`"
+    },
+    {
+        "class": "event_definition",
+        "input": {
+            "set_notification_message": {
                 "value": "value"
             }
         },

--- a/tests/src/notification_message_manager/CMakeLists.txt
+++ b/tests/src/notification_message_manager/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
+
+include (../../tests.cmake)
+
+project (karabiner_test)
+
+add_executable(
+  karabiner_test
+  src/test.cpp
+)
+
+target_link_libraries(
+  karabiner_test
+  libduktape
+  "-framework CoreFoundation"
+  "-framework CoreGraphics"
+)

--- a/tests/src/notification_message_manager/Makefile
+++ b/tests/src/notification_message_manager/Makefile
@@ -1,0 +1,6 @@
+all: build_make
+	MallocNanoZone=0 ./build/karabiner_test
+
+clean: clean_builds
+
+include ../Makefile.rules

--- a/tests/src/notification_message_manager/src/test.cpp
+++ b/tests/src/notification_message_manager/src/test.cpp
@@ -1,0 +1,101 @@
+#include "../../../src/share/notification_message_manager.hpp"
+#include <boost/ut.hpp>
+#include <pqrs/gsl.hpp>
+#include <pqrs/thread_wait.hpp>
+
+namespace {
+class manager_test_context final {
+public:
+  manager_test_context()
+      : manager_(pqrs::make_weak(dispatcher_)) {
+    time_source_->set_now(pqrs::dispatcher::time_point(std::chrono::milliseconds(0)));
+  }
+
+  krbn::notification_message_manager& get_manager() {
+    return manager_;
+  }
+
+  void flush_immediate_dispatcher_jobs(std::size_t rounds = 4) {
+    for (std::size_t i = 0; i < rounds; ++i) {
+      auto wait = pqrs::make_thread_wait();
+
+      manager_.enqueue_to_dispatcher([wait] {
+        wait->notify();
+      });
+
+      wait->wait_notice();
+    }
+  }
+
+  void wait_until(std::chrono::milliseconds ms) {
+    auto wait = pqrs::make_thread_wait();
+    auto when = pqrs::dispatcher::time_point(ms);
+
+    time_source_->set_now(when);
+    boost::ut::expect(manager_.enqueue_to_dispatcher(
+        [wait] {
+          wait->notify();
+        },
+        when));
+    wait->wait_notice();
+  }
+
+private:
+  pqrs::not_null_shared_ptr_t<pqrs::dispatcher::pseudo_time_source> time_source_ = std::make_shared<pqrs::dispatcher::pseudo_time_source>();
+  pqrs::not_null_shared_ptr_t<pqrs::dispatcher::dispatcher> dispatcher_ = std::make_shared<pqrs::dispatcher::dispatcher>(time_source_.get());
+  krbn::notification_message_manager manager_;
+};
+
+krbn::notification_message make_notification_message(const std::string& text,
+                                                     std::chrono::milliseconds duration_milliseconds) {
+  auto message = krbn::notification_message();
+  message.set_id("test");
+  message.set_text(text);
+  message.set_duration_milliseconds(duration_milliseconds);
+  return message;
+}
+} // namespace
+
+int main() {
+  using namespace boost::ut;
+  using namespace boost::ut::literals;
+
+  "notification_message_manager duration_milliseconds"_test = [] {
+    auto c = manager_test_context();
+
+    c.get_manager().async_set_notification_message(
+        make_notification_message("first", std::chrono::milliseconds(50)));
+    c.flush_immediate_dispatcher_jobs();
+
+    expect(c.get_manager().get_full_message() == "first");
+
+    c.wait_until(std::chrono::milliseconds(40));
+    expect(c.get_manager().get_full_message() == "first");
+
+    c.wait_until(std::chrono::milliseconds(60));
+    expect(c.get_manager().get_full_message().empty());
+  };
+
+  "notification_message_manager duration reset"_test = [] {
+    auto c = manager_test_context();
+
+    c.get_manager().async_set_notification_message(
+        make_notification_message("first", std::chrono::milliseconds(50)));
+    c.flush_immediate_dispatcher_jobs();
+
+    c.wait_until(std::chrono::milliseconds(40));
+    c.get_manager().async_set_notification_message(
+        make_notification_message("second", std::chrono::milliseconds(50)));
+    c.flush_immediate_dispatcher_jobs();
+
+    expect(c.get_manager().get_full_message() == "second");
+
+    c.wait_until(std::chrono::milliseconds(80));
+    expect(c.get_manager().get_full_message() == "second");
+
+    c.wait_until(std::chrono::milliseconds(100));
+    expect(c.get_manager().get_full_message().empty());
+  };
+
+  return 0;
+}

--- a/tests/src/types/src/notification_message_test.hpp
+++ b/tests/src/types/src/notification_message_test.hpp
@@ -1,3 +1,4 @@
+#include "test.hpp"
 #include "types.hpp"
 #include <boost/ut.hpp>
 
@@ -15,8 +16,48 @@ void run_notification_message_test() {
       auto value = json.get<krbn::notification_message>();
       expect(value.get_id() == "notification_message_id");
       expect(value.get_text() == "notification_message_text");
+      expect(value.get_duration_milliseconds() == std::chrono::milliseconds(0));
 
       expect(nlohmann::json(value) == json);
     }
+    {
+      auto json = nlohmann::json::object({
+          {"id", "notification_message_id"},
+          {"text", "notification_message_text"},
+          {"duration_milliseconds", 3000},
+      });
+
+      auto value = json.get<krbn::notification_message>();
+      expect(value.get_id() == "notification_message_id");
+      expect(value.get_text() == "notification_message_text");
+      expect(value.get_duration_milliseconds() == std::chrono::milliseconds(3000));
+
+      expect(nlohmann::json(value) == json);
+    }
+    {
+      auto json = nlohmann::json::object({
+          {"id", "notification_message_id"},
+          {"text", "notification_message_text"},
+          {"duration_milliseconds", 0},
+      });
+
+      auto value = json.get<krbn::notification_message>();
+      expect(value.get_duration_milliseconds() == std::chrono::milliseconds(0));
+
+      json.erase("duration_milliseconds");
+      expect(nlohmann::json(value) == json);
+    }
+
+    json_unmarshal_error_test<krbn::notification_message>(
+        nlohmann::json::object({
+            {"duration_milliseconds", nullptr},
+        }),
+        "`duration_milliseconds` must be number, but is `null`");
+
+    json_unmarshal_error_test<krbn::notification_message>(
+        nlohmann::json::object({
+            {"duration_milliseconds", -1},
+        }),
+        "`duration_milliseconds` must be greater than or equal to 0, but is `-1`");
   };
 }


### PR DESCRIPTION
## Summary
- add optional `duration_milliseconds` to `set_notification_message` JSON
- automatically clear user notification messages after the configured duration
- add parser/error coverage and a manager behavior test for expiration/reset

Fixes #3956

## Tests
- `make -C tests/src/notification_message_manager`
- `make -C tests/src/types`
- `make -C tests/src/manipulator_types`
- `make -C tests/src/fn_function_keys_manipulator_manager`
- `bash tests/scripts/check-cmakelists.sh`