### PR TITLE
Add ctrl-click to command-click example

### DIFF
--- a/files/complex_modifications_rules_example.json
+++ b/files/complex_modifications_rules_example.json
@@ -133,6 +133,30 @@
                     ]
                 }
             ]
+        },
+        {
+            "description": "Change control-left click to command-left click",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": {
+                        "pointing_button": "button1",
+                        "modifiers": {
+                            "mandatory": [
+                                "control"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "pointing_button": "button1",
+                            "modifiers": [
+                                "command"
+                            ]
+                        }
+                    ]
+                }
+            ]
         }
     ]
 }

--- a/tests/src/complex_modifications_assets/src/complex_modifications_assets_file_test.hpp
+++ b/tests/src/complex_modifications_assets/src/complex_modifications_assets_file_test.hpp
@@ -23,4 +23,14 @@ void run_complex_modifications_assets_file_test() {
       expect(error_messages == assets_json_entry.at("errors").get<std::vector<std::string>>());
     }
   };
+
+  "examples"_test = [] {
+    auto file = krbn::complex_modifications_assets_file("../../../files/complex_modifications_rules_example.json",
+                                                        krbn::core_configuration::error_handling::strict);
+
+    expect(file.get_title() == "Examples");
+    expect(file.get_rules().size() == 4);
+    expect(file.get_rules().back()->get_description() == "Change control-left click to command-left click");
+    expect(file.lint().empty());
+  };
 }


### PR DESCRIPTION
## Summary
- add a bundled complex modification example that maps control-left click to command-left click
- cover the shipped examples file in the complex modifications assets test

Fixes #3887

## Tests
- `make -C tests/src/complex_modifications_assets`
- `jq empty files/complex_modifications_rules_example.json`
- `git diff --check`
- `bash tests/scripts/check-cmakelists.sh`