### PR TITLE
Add notification window position setting

### DIFF
--- a/src/apps/ConsoleUserServer/include/console_user_server/components_manager.hpp
+++ b/src/apps/ConsoleUserServer/include/console_user_server/components_manager.hpp
@@ -200,6 +200,7 @@ private:
                     "notificationWindowSettings",
                     {
                         {"enabled", global_configuration.get_enable_notification_window()},
+                        {"position", global_configuration.get_notification_window_position()},
                     },
                 },
                 {

--- a/src/apps/ConsoleUserServer/swift/ConsoleUserServerUIState.swift
+++ b/src/apps/ConsoleUserServer/swift/ConsoleUserServerUIState.swift
@@ -11,6 +11,7 @@ struct UIStatePayload: Decodable {
 
   struct NotificationWindowSettings: Decodable {
     var enabled = false
+    var position = "bottom_right"
   }
 
   struct Profile: Decodable, Identifiable {

--- a/src/apps/ConsoleUserServer/swift/NotificationWindowManager.swift
+++ b/src/apps/ConsoleUserServer/swift/NotificationWindowManager.swift
@@ -55,10 +55,21 @@ final class NotificationWindowManager: NSObject {
   func updateWindowsFrameOrigin(_ screens: [NSScreen] = NSScreen.screens) {
     for (index, window) in screenWindows.enumerated() {
       let frame = screens[index].visibleFrame
+      let windowSize = window.contentView?.fittingSize ?? NSSize(width: 410.0, height: 70.0)
+      let position = ConsoleUserServerUIState.shared.notificationWindowSettings.position
+      let x = frame.origin.x + frame.width - windowSize.width
+      let y: CGFloat
+
+      if position == "top_right" {
+        y = frame.origin.y + frame.height - windowSize.height - 10.0
+      } else {
+        y = frame.origin.y + 10.0
+      }
+
       window.setFrameOrigin(
         NSPoint(
-          x: frame.origin.x + frame.width - 410.0,
-          y: frame.origin.y + 10.0))
+          x: x,
+          y: y))
     }
   }
 
@@ -67,6 +78,11 @@ final class NotificationWindowManager: NSObject {
     let hide =
       !state.configurationLoaded || !state.notificationWindowSettings.enabled
       || state.notificationMessage.isEmpty
+
+    if !hide {
+      updateWindowsFrameOrigin()
+    }
+
     for window in screenWindows {
       if hide {
         window.orderOut(self)

--- a/src/apps/SettingsWindow/src/SettingsConfiguration.swift
+++ b/src/apps/SettingsWindow/src/SettingsConfiguration.swift
@@ -20,6 +20,7 @@ struct SettingsConfiguration: Decodable {
     var showProfileNameInMenuBar: Bool
     var showAdditionalMenuItems: Bool
     var enableNotificationWindow: Bool
+    var notificationWindowPosition: String
     var unsafeUi: Bool
     var filterUselessEventsFromSpecificDevices: Bool
     var reorderSameTimestampInputEventsToPrioritizeModifiers: Bool

--- a/src/apps/SettingsWindow/src/View/UIView.swift
+++ b/src/apps/SettingsWindow/src/View/UIView.swift
@@ -35,6 +35,15 @@ struct UIView: View {
             }
             .switchToggleStyle()
 
+            Picker(
+              selection: $settings.configuration.globalConfiguration.notificationWindowPosition,
+              label: Text("Position")
+            ) {
+              Text("Bottom right").tag("bottom_right")
+              Text("Top right").tag("top_right")
+            }
+            .pickerStyle(.radioGroup)
+
             Toggle(
               isOn: $settings.configuration.selectedProfile.virtualHidKeyboard
                 .indicateStickyModifierKeysState
@@ -46,8 +55,8 @@ struct UIView: View {
             VStack(alignment: .leading, spacing: 12.0) {
               Label(
                 "What is the Karabiner Notification Window?\n\n"
-                  + "Karabiner Notification Window is a window that displays messages, located at the bottom right of the screen."
-                  + "It is used for temporary alerts, displaying the status of sticky modifiers, and showing messages for some complex modifications.",
+                  + "Karabiner Notification Window is a window that displays messages."
+                  + " It is used for temporary alerts, displaying the status of sticky modifiers, and showing messages for some complex modifications.",
                 systemImage: InfoBorder.icon
               )
 

--- a/src/apps/SettingsWindow/src/cpp/settings_configuration_snapshot.hpp
+++ b/src/apps/SettingsWindow/src/cpp/settings_configuration_snapshot.hpp
@@ -37,6 +37,7 @@ public:
              {"show_profile_name_in_menu_bar", global.get_show_profile_name_in_menu_bar()},
              {"show_additional_menu_items", global.get_show_additional_menu_items()},
              {"enable_notification_window", global.get_enable_notification_window()},
+             {"notification_window_position", global.get_notification_window_position()},
              {"unsafe_ui", global.get_unsafe_ui()},
              {"filter_useless_events_from_specific_devices", global.get_filter_useless_events_from_specific_devices()},
              {"reorder_same_timestamp_input_events_to_prioritize_modifiers", global.get_reorder_same_timestamp_input_events_to_prioritize_modifiers()},

--- a/src/apps/SettingsWindow/src/cpp/settings_configuration_updater.hpp
+++ b/src/apps/SettingsWindow/src/cpp/settings_configuration_updater.hpp
@@ -32,6 +32,10 @@ public:
                                    "enable_notification_window",
                                    global.get_enable_notification_window(),
                                    [&](auto value) { global.set_enable_notification_window(value); });
+      changed |= apply_value<std::string>(global_json,
+                                          "notification_window_position",
+                                          global.get_notification_window_position(),
+                                          [&](const auto& value) { global.set_notification_window_position(value); });
       changed |= apply_value<bool>(global_json,
                                    "unsafe_ui",
                                    global.get_unsafe_ui(),

--- a/src/share/core_configuration/details/global_configuration.hpp
+++ b/src/share/core_configuration/details/global_configuration.hpp
@@ -2,6 +2,7 @@
 
 #include "../configuration_json_helper.hpp"
 #include <pqrs/json.hpp>
+#include <string>
 
 namespace krbn::core_configuration::details {
 class global_configuration final {
@@ -31,6 +32,10 @@ public:
                                          enable_notification_window_,
                                          true);
 
+    helper_values_.push_back_value<std::string>("notification_window_position",
+                                                notification_window_position_,
+                                                "bottom_right");
+
     helper_values_.push_back_value<bool>("unsafe_ui",
                                          unsafe_ui_,
                                          false);
@@ -57,6 +62,8 @@ public:
     json_.erase("ask_for_confirmation_before_quitting");
 
     helper_values_.update_value(json_, error_handling);
+
+    set_notification_window_position(notification_window_position_);
   }
 
   nlohmann::json to_json() const {
@@ -102,6 +109,17 @@ public:
     enable_notification_window_ = value;
   }
 
+  [[nodiscard]] const std::string& get_notification_window_position() const {
+    return notification_window_position_;
+  }
+  void set_notification_window_position(const std::string& value) {
+    if (value == "top_right") {
+      notification_window_position_ = value;
+    } else {
+      notification_window_position_ = "bottom_right";
+    }
+  }
+
   [[nodiscard]] const bool& get_unsafe_ui() const {
     return unsafe_ui_;
   }
@@ -137,6 +155,7 @@ private:
   bool show_profile_name_in_menu_bar_;
   bool show_additional_menu_items_;
   bool enable_notification_window_;
+  std::string notification_window_position_;
   bool unsafe_ui_;
   bool filter_useless_events_from_specific_devices_;
   bool reorder_same_timestamp_input_events_to_prioritize_modifiers_;

--- a/tests/src/core_configuration/src/global_configuration_test.hpp
+++ b/tests/src/core_configuration/src/global_configuration_test.hpp
@@ -16,6 +16,7 @@ void run_global_configuration_test() {
       expect(global_configuration.get_show_profile_name_in_menu_bar() == false);
       expect(global_configuration.get_show_additional_menu_items() == false);
       expect(global_configuration.get_enable_notification_window() == true);
+      expect(global_configuration.get_notification_window_position() == "bottom_right");
       expect(global_configuration.get_unsafe_ui() == false);
       expect(global_configuration.get_filter_useless_events_from_specific_devices() == true);
       expect(global_configuration.get_reorder_same_timestamp_input_events_to_prioritize_modifiers() == true);
@@ -30,6 +31,7 @@ void run_global_configuration_test() {
           {"show_profile_name_in_menu_bar", true},
           {"show_additional_menu_items", true},
           {"enable_notification_window", false},
+          {"notification_window_position", "top_right"},
           {"unsafe_ui", true},
           {"filter_useless_events_from_specific_devices", false},
           {"reorder_same_timestamp_input_events_to_prioritize_modifiers", false},
@@ -42,6 +44,7 @@ void run_global_configuration_test() {
       expect(global_configuration.get_show_profile_name_in_menu_bar() == true);
       expect(global_configuration.get_show_additional_menu_items() == true);
       expect(global_configuration.get_enable_notification_window() == false);
+      expect(global_configuration.get_notification_window_position() == "top_right");
       expect(global_configuration.get_unsafe_ui() == true);
       expect(global_configuration.get_filter_useless_events_from_specific_devices() == false);
       expect(global_configuration.get_reorder_same_timestamp_input_events_to_prioritize_modifiers() == false);
@@ -56,6 +59,7 @@ void run_global_configuration_test() {
       global_configuration.set_show_profile_name_in_menu_bar(false);
       global_configuration.set_show_additional_menu_items(false);
       global_configuration.set_enable_notification_window(true);
+      global_configuration.set_notification_window_position("bottom_right");
       global_configuration.set_unsafe_ui(false);
       global_configuration.set_filter_useless_events_from_specific_devices(true);
       global_configuration.set_reorder_same_timestamp_input_events_to_prioritize_modifiers(true);
@@ -72,6 +76,7 @@ void run_global_configuration_test() {
           {"show_profile_name_in_menu_bar", nlohmann::json::object()},
           {"show_additional_menu_items", nlohmann::json::object()},
           {"enable_notification_window", nlohmann::json::object()},
+          {"notification_window_position", nlohmann::json::object()},
           {"unsafe_ui", nlohmann::json::object()},
           {"filter_useless_events_from_specific_devices", nlohmann::json::object()},
           {"reorder_same_timestamp_input_events_to_prioritize_modifiers", nlohmann::json::object()},
@@ -84,10 +89,21 @@ void run_global_configuration_test() {
       expect(global_configuration.get_show_profile_name_in_menu_bar() == false);
       expect(global_configuration.get_show_additional_menu_items() == false);
       expect(global_configuration.get_enable_notification_window() == true);
+      expect(global_configuration.get_notification_window_position() == "bottom_right");
       expect(global_configuration.get_unsafe_ui() == false);
       expect(global_configuration.get_filter_useless_events_from_specific_devices() == true);
       expect(global_configuration.get_reorder_same_timestamp_input_events_to_prioritize_modifiers() == true);
       expect(global_configuration.get_enable_cgeventtap_fallback() == false);
+    }
+
+    // invalid notification_window_position in json
+    {
+      nlohmann::json json{
+          {"notification_window_position", "unknown"},
+      };
+      krbn::core_configuration::details::global_configuration global_configuration(json,
+                                                                                   krbn::core_configuration::error_handling::strict);
+      expect(global_configuration.get_notification_window_position() == "bottom_right");
     }
 
     // migrate from check_for_updates_on_startup


### PR DESCRIPTION
Summary
- Add a global notification_window_position setting with bottom_right as the default and top_right as the supported alternative.
- Expose the setting in the UI tab as a position picker.
- Pass the setting to ConsoleUserServer and reposition notification windows before showing them.

Validation
- make -C tests/src/core_configuration
- xcrun swift-format -i src/apps/ConsoleUserServer/swift/ConsoleUserServerUIState.swift src/apps/ConsoleUserServer/swift/NotificationWindowManager.swift src/apps/SettingsWindow/src/SettingsConfiguration.swift src/apps/SettingsWindow/src/View/UIView.swift
- xcodebuild -configuration Release -alltargets SYMROOT="$(pwd)/build" CODE_SIGNING_ALLOWED=NO -quiet (src/apps/SettingsWindow)
- xcodebuild -configuration Release -alltargets SYMROOT="$(pwd)/build" CODE_SIGNING_ALLOWED=NO -quiet (src/apps/ConsoleUserServer)
- git diff --check
- bash tests/scripts/check-cmakelists.sh

Fixes #4097