### PR TITLE
Refresh Core Service agent registration on install

### DIFF
--- a/pkginfo/Scripts/postinstall
+++ b/pkginfo/Scripts/postinstall
@@ -29,6 +29,19 @@ fi
 tar -C /Applications -cf '/Library/Application Support/org.pqrs/Karabiner-Elements/Karabiner-Elements.app.tar.gz' Karabiner-Elements.app
 
 #
+# Refresh SMAppService agent registrations after all files have been updated.
+#
+
+console_user=$(stat -f %Su /dev/console)
+console_user_uid=$(stat -f %u /dev/console)
+non_privileged_agents='/Library/Application Support/org.pqrs/Karabiner-Elements/Karabiner-Elements Non-Privileged Agents v2.app/Contents/MacOS/Karabiner-Elements Non-Privileged Agents v2'
+
+if [ "$console_user" != 'root' ] && [ "$console_user_uid" != '0' ] && [ -x "$non_privileged_agents" ]; then
+    launchctl asuser "$console_user_uid" sudo -u "$console_user" "$non_privileged_agents" unregister-core-agents
+    launchctl asuser "$console_user_uid" sudo -u "$console_user" "$non_privileged_agents" register-core-agents
+fi
+
+#
 # Relaunch launchd-managed processes after all files have been updated
 #
 

--- a/src/apps/ServiceManager-Non-Privileged-Agents/LaunchAgents/org.pqrs.service.agent.Karabiner-Core-Service.plist
+++ b/src/apps/ServiceManager-Non-Privileged-Agents/LaunchAgents/org.pqrs.service.agent.Karabiner-Core-Service.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
   <dict>
     <key>Label</key>
-    <string>org.pqrs.service.agent.Karabiner-Core-Service-rev2</string>
+    <string>org.pqrs.service.agent.Karabiner-Core-Service</string>
     <key>KeepAlive</key>
     <true/>
     <key>ProgramArguments</key>


### PR DESCRIPTION
Summary
- Refresh the Core Service LaunchAgent registration during postinstall by unregistering and registering core agents for the current console user after updated files are installed.
- Align the Core Service LaunchAgent Label with the plist file name and SMAppService registration name so the refreshed registration uses the expected label.

Validation
- bash -n pkginfo/Scripts/postinstall pkginfo/Scripts/preinstall
- plutil -lint src/apps/ServiceManager-Non-Privileged-Agents/LaunchAgents/org.pqrs.service.agent.Karabiner-Core-Service.plist
- xcodegen generate && xcodebuild -configuration Release -alltargets SYMROOT="$(pwd)/build" CODE_SIGNING_ALLOWED=NO -quiet (src/apps/ServiceManager-Non-Privileged-Agents; after running update_version.py to generate Info.plist)
- git diff --check

Fixes #4496