### PR TITLE
Add default mouse modification setting

### DIFF
--- a/src/apps/SettingsWindow/src/SettingsConfiguration.swift
+++ b/src/apps/SettingsWindow/src/SettingsConfiguration.swift
@@ -186,6 +186,7 @@ struct SettingsConfiguration: Decodable {
       var indicateStickyModifierKeysState: Bool
     }
 
+    var modifyMouseEventsByDefault: Bool
     var parameters: Parameters
     let simpleModifications: [SimpleModification]
     let fnFunctionKeys: [SimpleModification]
@@ -210,6 +211,7 @@ struct SettingsConfigurationUpdate: Encodable {
       let parameters: SettingsConfiguration.SelectedProfile.ComplexModifications.Parameters
     }
 
+    let modifyMouseEventsByDefault: Bool
     let parameters: SettingsConfiguration.SelectedProfile.Parameters
     let devices: [String: SettingsConfiguration.Device]
     let complexModifications: ComplexModifications
@@ -224,6 +226,7 @@ struct SettingsConfigurationUpdate: Encodable {
     globalConfiguration = configuration.globalConfiguration
     machineSpecific = configuration.machineSpecific
     selectedProfile = SelectedProfile(
+      modifyMouseEventsByDefault: configuration.selectedProfile.modifyMouseEventsByDefault,
       parameters: configuration.selectedProfile.parameters,
       devices: configuration.selectedProfile.devices,
       complexModifications: SelectedProfile.ComplexModifications(

--- a/src/apps/SettingsWindow/src/View/DevicesView.swift
+++ b/src/apps/SettingsWindow/src/View/DevicesView.swift
@@ -9,6 +9,12 @@ struct DevicesView: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0.0) {
+      Toggle(isOn: $settings.configuration.selectedProfile.modifyMouseEventsByDefault) {
+        Text("Modify mouse events by default")
+      }
+      .switchToggleStyle()
+      .padding()
+
       List {
         ForEach(connectedDevices.connectedDevices) { connectedDevice in
           if let deviceConfiguration = settings.deviceConfigurationBinding(connectedDevice) {

--- a/src/apps/SettingsWindow/src/cpp/settings_configuration_snapshot.hpp
+++ b/src/apps/SettingsWindow/src/cpp/settings_configuration_snapshot.hpp
@@ -50,6 +50,7 @@ public:
         {"profiles", profiles},
         {"selected_profile",
          {
+             {"modify_mouse_events_by_default", selected_profile.get_modify_mouse_events_by_default()},
              {"parameters",
               {
                   {"delay_milliseconds_before_open_device", selected_profile.get_parameters()->get_delay_milliseconds_before_open_device().count()},

--- a/src/apps/SettingsWindow/src/cpp/settings_configuration_updater.hpp
+++ b/src/apps/SettingsWindow/src/cpp/settings_configuration_updater.hpp
@@ -67,6 +67,11 @@ public:
       auto& selected_profile = core_configuration.get_selected_profile();
       const auto& selected_profile_json = *it;
 
+      changed |= apply_value<bool>(selected_profile_json,
+                                   "modify_mouse_events_by_default",
+                                   selected_profile.get_modify_mouse_events_by_default(),
+                                   [&](auto value) { selected_profile.set_modify_mouse_events_by_default(value); });
+
       if (const auto parameters_it = selected_profile_json.find("parameters");
           parameters_it != selected_profile_json.end()) {
         auto parameters = selected_profile.get_parameters();

--- a/src/share/core_configuration/details/profile.hpp
+++ b/src/share/core_configuration/details/profile.hpp
@@ -31,6 +31,10 @@ public:
                                          selected_,
                                          false);
 
+    helper_values_.push_back_value<bool>("modify_mouse_events_by_default",
+                                         modify_mouse_events_by_default_,
+                                         false);
+
     helper_values_.push_back_object<details::parameters>("parameters",
                                                          parameters_);
 
@@ -78,6 +82,8 @@ public:
         }
       }
     }
+
+    update_devices_default_values();
   }
 
   static nlohmann::json make_default_fn_function_keys_json() {
@@ -188,6 +194,16 @@ public:
     selected_ = value;
   }
 
+  [[nodiscard]] const bool& get_modify_mouse_events_by_default() const {
+    return modify_mouse_events_by_default_;
+  }
+
+  void set_modify_mouse_events_by_default(bool value) {
+    modify_mouse_events_by_default_ = value;
+
+    update_devices_default_values();
+  }
+
   [[nodiscard]] pqrs::not_null_shared_ptr_t<details::parameters> get_parameters() const {
     return parameters_;
   }
@@ -230,10 +246,12 @@ public:
     // Add device
     //
 
-    devices_.push_back(std::make_shared<details::device>(nlohmann::json({
-                                                             {"identifiers", identifiers},
-                                                         }),
-                                                         error_handling_));
+    auto device = std::make_shared<details::device>(nlohmann::json({
+                                                        {"identifiers", identifiers},
+                                                    }),
+                                                    error_handling_);
+    update_device_default_values(*device);
+    devices_.push_back(device);
     return devices_.back();
   }
 
@@ -261,6 +279,7 @@ private:
   error_handling error_handling_;
   std::string name_;
   bool selected_;
+  bool modify_mouse_events_by_default_;
   pqrs::not_null_shared_ptr_t<details::parameters> parameters_;
   pqrs::not_null_shared_ptr_t<simple_modifications> simple_modifications_;
   pqrs::not_null_shared_ptr_t<simple_modifications> fn_function_keys_;
@@ -268,6 +287,18 @@ private:
   pqrs::not_null_shared_ptr_t<details::virtual_hid_keyboard> virtual_hid_keyboard_;
   mutable std::vector<pqrs::not_null_shared_ptr_t<details::device>> devices_;
   configuration_json_helper::helper_values helper_values_;
+
+  void update_devices_default_values() const {
+    for (const auto& device : devices_) {
+      update_device_default_values(*device);
+    }
+  }
+
+  void update_device_default_values(details::device& device) const {
+    if (device.get_identifiers().get_is_pointing_device()) {
+      device.set_ignore_default_value(!modify_mouse_events_by_default_);
+    }
+  }
 };
 
 inline void to_json(nlohmann::json& json, const profile& profile) {

--- a/src/share/core_configuration/details/profile/device.hpp
+++ b/src/share/core_configuration/details/profile/device.hpp
@@ -333,6 +333,12 @@ cos(radian) * m;
 
     coordinate_between_properties();
   }
+  void set_ignore_default_value(bool value) {
+    helper_values_.set_default_value(ignore_,
+                                     value);
+
+    coordinate_between_properties();
+  }
 
   [[nodiscard]] const bool& get_manipulate_caps_lock_led() const {
     return manipulate_caps_lock_led_;

--- a/tests/src/core_configuration/src/core_configuration_test.hpp
+++ b/tests/src/core_configuration/src/core_configuration_test.hpp
@@ -127,6 +127,73 @@ void run_core_configuration_test() {
     }
   };
 
+  "profile.modify_mouse_events_by_default"_test = [] {
+    {
+      krbn::core_configuration::details::profile profile(nlohmann::json::object(),
+                                                         krbn::core_configuration::error_handling::strict);
+      expect(profile.get_modify_mouse_events_by_default() == false);
+
+      auto identifiers = nlohmann::json::object({
+                             {"vendor_id", 1234},
+                             {"product_id", 5678},
+                             {"is_pointing_device", true},
+                         })
+                             .get<krbn::device_identifiers>();
+      expect(profile.get_device(identifiers)->get_ignore() == true);
+    }
+
+    {
+      nlohmann::json json({
+          {"modify_mouse_events_by_default", true},
+          {"devices", nlohmann::json::array({
+                          {
+                              {"identifiers", {
+                                                  {"vendor_id", 1234},
+                                                  {"product_id", 5678},
+                                                  {"is_pointing_device", true},
+                                              }},
+                          },
+                          {
+                              {"identifiers", {
+                                                  {"vendor_id", 1235},
+                                                  {"product_id", 5678},
+                                                  {"is_pointing_device", true},
+                                              }},
+                              {"ignore", true},
+                          },
+                          {
+                              {"identifiers", {
+                                                  {"vendor_id", 1236},
+                                                  {"product_id", 5678},
+                                                  {"is_keyboard", true},
+                                              }},
+                          },
+                      })},
+      });
+
+      krbn::core_configuration::details::profile profile(json,
+                                                         krbn::core_configuration::error_handling::strict);
+      expect(profile.get_modify_mouse_events_by_default() == true);
+      expect(profile.get_devices()[0]->get_ignore() == false);
+      expect(profile.get_devices()[1]->get_ignore() == true);
+      expect(profile.get_devices()[2]->get_ignore() == false);
+
+      auto identifiers = nlohmann::json::object({
+                             {"vendor_id", 1237},
+                             {"product_id", 5678},
+                             {"is_pointing_device", true},
+                         })
+                             .get<krbn::device_identifiers>();
+      expect(profile.get_device(identifiers)->get_ignore() == false);
+
+      profile.set_modify_mouse_events_by_default(false);
+      expect(profile.get_devices()[0]->get_ignore() == true);
+      expect(profile.get_devices()[1]->get_ignore() == true);
+      expect(profile.get_devices()[2]->get_ignore() == false);
+      expect(profile.get_device(identifiers)->get_ignore() == true);
+    }
+  };
+
   "not found"_test = [] {
     {
       krbn::core_configuration::core_configuration configuration("json/not_found.json",


### PR DESCRIPTION
Summary
- Add a per-profile modify_mouse_events_by_default setting, disabled by default for compatibility.
- When enabled, new or default-configured pointing devices start with event modification enabled while explicit per-device ignore settings keep priority.
- Expose the setting in the Devices tab.

Validation
- make -C tests/src/core_configuration
- xcrun swift-format -i src/apps/SettingsWindow/src/SettingsConfiguration.swift src/apps/SettingsWindow/src/View/DevicesView.swift
- xcodebuild -configuration Release -alltargets SYMROOT="$(pwd)/build" CODE_SIGNING_ALLOWED=NO -quiet (src/apps/SettingsWindow)
- git diff --check
- bash tests/scripts/check-cmakelists.sh

Fixes #4289