### PR TITLE
Add support for mouse tilt as buttons

### DIFF
--- a/src/apps/CoreService/include/core_service/daemon/device_grabber_details/simple_modifications_manipulator_manager.hpp
+++ b/src/apps/CoreService/include/core_service/daemon/device_grabber_details/simple_modifications_manipulator_manager.hpp
@@ -83,13 +83,19 @@ public:
           discard.push_back("horizontal_wheel");
         }
 
-        if (flip.size() > 0 || swap.size() > 0 || discard.size() > 0) {
+        auto to_buttons = nlohmann::json::array();
+        if (device->get_mouse_horizontal_wheel_to_buttons()) {
+          to_buttons.push_back("horizontal_wheel");
+        }
+
+        if (flip.size() > 0 || swap.size() > 0 || discard.size() > 0 || to_buttons.size() > 0) {
           try {
             auto json = nlohmann::json::object({
                 {"type", "mouse_basic"},
                 {"flip", flip},
                 {"swap", swap},
                 {"discard", discard},
+                {"to_buttons", to_buttons},
             });
             auto parameters = std::make_shared<krbn::core_configuration::details::complex_modifications_parameters>();
             auto m = std::make_shared<manipulator::manipulators::mouse_basic::mouse_basic>(json,

--- a/src/apps/SettingsWindow/src/SettingsConfiguration.swift
+++ b/src/apps/SettingsWindow/src/SettingsConfiguration.swift
@@ -168,6 +168,7 @@ struct SettingsConfiguration: Decodable {
     var mouseDiscardY: Bool
     var mouseDiscardVerticalWheel: Bool
     var mouseDiscardHorizontalWheel: Bool
+    var mouseHorizontalWheelToButtons: Bool
     var mouseSwapXy: Bool
     var mouseSwapWheels: Bool
     var gamePadSwapSticks: Bool

--- a/src/apps/SettingsWindow/src/View/DevicesMouseFlagsView.swift
+++ b/src/apps/SettingsWindow/src/View/DevicesMouseFlagsView.swift
@@ -72,8 +72,14 @@ struct DevicesMouseFlagsView: View {
               .frame(maxWidth: .infinity, alignment: .leading)
           }
           .switchToggleStyle(controlSize: .mini, font: .callout)
+
+          Toggle(isOn: $deviceConfiguration.mouseHorizontalWheelToButtons) {
+            Text("Treat mouse horizontal wheel as buttons")
+              .frame(maxWidth: .infinity, alignment: .leading)
+          }
+          .switchToggleStyle(controlSize: .mini, font: .callout)
         }
-        .frame(width: 160.0)
+        .frame(width: 220.0)
       }
       .padding()
     }

--- a/src/apps/SettingsWindow/src/cpp/settings_configuration_snapshot.hpp
+++ b/src/apps/SettingsWindow/src/cpp/settings_configuration_snapshot.hpp
@@ -189,6 +189,7 @@ private:
           {"mouse_discard_y", device->get_mouse_discard_y()},
           {"mouse_discard_vertical_wheel", device->get_mouse_discard_vertical_wheel()},
           {"mouse_discard_horizontal_wheel", device->get_mouse_discard_horizontal_wheel()},
+          {"mouse_horizontal_wheel_to_buttons", device->get_mouse_horizontal_wheel_to_buttons()},
           {"mouse_swap_xy", device->get_mouse_swap_xy()},
           {"mouse_swap_wheels", device->get_mouse_swap_wheels()},
           {"game_pad_swap_sticks", device->get_game_pad_swap_sticks()},

--- a/src/apps/SettingsWindow/src/cpp/settings_configuration_updater.hpp
+++ b/src/apps/SettingsWindow/src/cpp/settings_configuration_updater.hpp
@@ -136,6 +136,7 @@ public:
           changed |= apply_value<bool>(device_json, "mouse_discard_y", [&](auto value) { device->set_mouse_discard_y(value); });
           changed |= apply_value<bool>(device_json, "mouse_discard_vertical_wheel", [&](auto value) { device->set_mouse_discard_vertical_wheel(value); });
           changed |= apply_value<bool>(device_json, "mouse_discard_horizontal_wheel", [&](auto value) { device->set_mouse_discard_horizontal_wheel(value); });
+          changed |= apply_value<bool>(device_json, "mouse_horizontal_wheel_to_buttons", [&](auto value) { device->set_mouse_horizontal_wheel_to_buttons(value); });
           changed |= apply_value<bool>(device_json, "mouse_swap_xy", [&](auto value) { device->set_mouse_swap_xy(value); });
           changed |= apply_value<bool>(device_json, "mouse_swap_wheels", [&](auto value) { device->set_mouse_swap_wheels(value); });
           changed |= apply_value<bool>(device_json, "game_pad_swap_sticks", [&](auto value) { device->set_game_pad_swap_sticks(value); });

--- a/src/share/core_configuration/details/profile/device.hpp
+++ b/src/share/core_configuration/details/profile/device.hpp
@@ -122,6 +122,10 @@ public:
                                          mouse_discard_horizontal_wheel_,
                                          false);
 
+    helper_values_.push_back_value<bool>("mouse_horizontal_wheel_to_buttons",
+                                         mouse_horizontal_wheel_to_buttons_,
+                                         false);
+
     helper_values_.push_back_value<bool>("game_pad_swap_sticks",
                                          game_pad_swap_sticks_,
                                          false);
@@ -531,6 +535,15 @@ cos(radian) * m;
     coordinate_between_properties();
   }
 
+  [[nodiscard]] const bool& get_mouse_horizontal_wheel_to_buttons() const {
+    return mouse_horizontal_wheel_to_buttons_;
+  }
+  void set_mouse_horizontal_wheel_to_buttons(bool value) {
+    mouse_horizontal_wheel_to_buttons_ = value;
+
+    coordinate_between_properties();
+  }
+
   [[nodiscard]] const bool& get_game_pad_swap_sticks() const {
     return game_pad_swap_sticks_;
   }
@@ -748,6 +761,7 @@ private:
   bool mouse_discard_y_;
   bool mouse_discard_vertical_wheel_;
   bool mouse_discard_horizontal_wheel_;
+  bool mouse_horizontal_wheel_to_buttons_;
   bool game_pad_swap_sticks_;
 
   double game_pad_xy_stick_deadzone_;

--- a/src/share/manipulator/manipulators/mouse_basic/mouse_basic.hpp
+++ b/src/share/manipulator/manipulators/mouse_basic/mouse_basic.hpp
@@ -18,7 +18,10 @@ public:
         discard_x_(false),
         discard_y_(false),
         discard_vertical_wheel_(false),
-        discard_horizontal_wheel_(false) {
+        discard_horizontal_wheel_(false),
+        to_buttons_horizontal_wheel_(false),
+        enabled_(false),
+        active_horizontal_wheel_button_(std::nullopt) {
     pqrs::json::requires_object(json, "json");
 
     for (const auto& [key, value] : json.items()) {
@@ -69,6 +72,17 @@ public:
           }
         }
 
+      } else if (key == "to_buttons") {
+        pqrs::json::requires_array(value, "`" + key + "`");
+
+        for (const auto& j : value) {
+          pqrs::json::requires_string(j, "items in `" + key + "`");
+
+          if (j == "horizontal_wheel") {
+            to_buttons_horizontal_wheel_ = true;
+          }
+        }
+
       } else if (key == "description" ||
                  key == "conditions" ||
                  key == "parameters" ||
@@ -79,6 +93,18 @@ public:
         throw pqrs::json::unmarshal_error(fmt::format("unknown key `{0}` in `{1}`", key, pqrs::json::dump_for_error_message(json)));
       }
     }
+
+    enabled_ = flip_x_ ||
+               flip_y_ ||
+               flip_vertical_wheel_ ||
+               flip_horizontal_wheel_ ||
+               swap_xy_ ||
+               swap_wheels_ ||
+               discard_x_ ||
+               discard_y_ ||
+               discard_vertical_wheel_ ||
+               discard_horizontal_wheel_ ||
+               to_buttons_horizontal_wheel_;
   }
 
   ~mouse_basic() override {
@@ -102,6 +128,10 @@ public:
       }
 
       if (validity_ == validity::invalid) {
+        // A config reload superseded this manipulator. Stop starting new `to_buttons`
+        // holds, but still release one we're already holding so it isn't left stuck
+        // on the virtual device once this (now-unreachable) instance is discarded.
+        release_horizontal_wheel_button_if_needed(front_input_event, output_event_queue);
         return manipulate_result::passed;
       }
 
@@ -119,16 +149,7 @@ public:
       //
 
       if (auto m = front_input_event.get_event().get_if<pointing_motion>()) {
-        if (flip_x_ ||
-            flip_y_ ||
-            flip_vertical_wheel_ ||
-            flip_horizontal_wheel_ ||
-            swap_xy_ ||
-            swap_wheels_ ||
-            discard_x_ ||
-            discard_y_ ||
-            discard_vertical_wheel_ ||
-            discard_horizontal_wheel_) {
+        if (enabled_) {
           front_input_event.set_validity(validity::invalid);
 
           auto motion = *m;
@@ -167,6 +188,23 @@ public:
             motion.set_horizontal_wheel(-motion.get_horizontal_wheel());
           }
 
+          // Convert horizontal wheel motion (a tilt-wheel switch) into a button hold instead
+          // of scroll motion, using button30/button31 since Karabiner-DriverKit-VirtualHIDPointing
+          // only reports buttons 1-32 (pointing_button_manager.hpp).
+
+          std::optional<pqrs::hid::usage::value_t> new_horizontal_wheel_button;
+          absolute_time_duration horizontal_wheel_button_time_stamp_delay(0);
+
+          if (to_buttons_horizontal_wheel_) {
+            if (motion.get_horizontal_wheel() < 0) {
+              new_horizontal_wheel_button = pqrs::hid::usage::button::button_30;
+            } else if (motion.get_horizontal_wheel() > 0) {
+              new_horizontal_wheel_button = pqrs::hid::usage::button::button_31;
+            }
+
+            motion.set_horizontal_wheel(0);
+          }
+
           if (discard_x_) {
             motion.set_x(0);
           }
@@ -192,6 +230,36 @@ public:
                                                  event_queue::state::manipulated,
                                                  front_input_event.get_lazy());
 
+          if (new_horizontal_wheel_button != active_horizontal_wheel_button_) {
+            // `manipulator::manipulators::basic` correlates a key_up with its key_down by
+            // comparing (device_id, event, original_event); real hardware buttons match
+            // because original_event is the button event itself. Follow the same
+            // self-referential convention so our down (from one pointing_motion tick) and
+            // up (from a later, different tick) are still recognized as a pair.
+            auto emit_button_event = [&](pqrs::hid::usage::value_t button, event_type type, int value) {
+              auto button_event = event_queue::event(momentary_switch_event(pqrs::hid::usage_page::button, button));
+              auto t = front_input_event.get_event_time_stamp();
+              t.set_time_stamp(t.get_time_stamp() + horizontal_wheel_button_time_stamp_delay++);
+              output_event_queue->emplace_back_entry(front_input_event.get_device_id(),
+                                                     t,
+                                                     button_event,
+                                                     type,
+                                                     event_integer_value::value_t(value),
+                                                     button_event,
+                                                     event_queue::state::manipulated);
+            };
+
+            if (active_horizontal_wheel_button_) {
+              emit_button_event(*active_horizontal_wheel_button_, event_type::key_up, 0);
+            }
+
+            if (new_horizontal_wheel_button) {
+              emit_button_event(*new_horizontal_wheel_button, event_type::key_down, 1);
+            }
+
+            active_horizontal_wheel_button_ = new_horizontal_wheel_button;
+          }
+
           return manipulate_result::manipulated;
         }
       }
@@ -201,7 +269,7 @@ public:
   }
 
   bool active() const override {
-    return false;
+    return active_horizontal_wheel_button_ != std::nullopt;
   }
 
   bool needs_virtual_hid_pointing() const override {
@@ -210,11 +278,16 @@ public:
 
   void handle_device_keys_and_pointing_buttons_are_released_event(const event_queue::entry& front_input_event,
                                                                   event_queue::queue& output_event_queue) override {
+    // The manager already erased active pointing buttons from `output_event_queue` before
+    // calling this. Keep our own held-button state in sync so a future tilt is not silently
+    // ignored because we still believe the button is down.
+    active_horizontal_wheel_button_ = std::nullopt;
   }
 
   void handle_device_ungrabbed_event(device_id device_id,
                                      const event_queue::queue& output_event_queue,
                                      absolute_time_point time_stamp) override {
+    active_horizontal_wheel_button_ = std::nullopt;
   }
 
   void handle_pointing_device_event_from_event_tap(const event_queue::entry& front_input_event,
@@ -222,6 +295,38 @@ public:
   }
 
 private:
+  void release_horizontal_wheel_button_if_needed(const event_queue::entry& front_input_event,
+                                                 std::shared_ptr<event_queue::queue> output_event_queue) {
+    if (!active_horizontal_wheel_button_) {
+      return;
+    }
+
+    auto m = front_input_event.get_event().get_if<pointing_motion>();
+    if (!m) {
+      return;
+    }
+
+    // `swap_wheels_` is the only one of our transforms that can move a nonzero value out of
+    // (or a zero value into) `horizontal_wheel`, so it's the only one we need to account for
+    // here to tell whether the switch has actually been released.
+    auto horizontal_wheel = swap_wheels_ ? m->get_vertical_wheel() : m->get_horizontal_wheel();
+    if (horizontal_wheel != 0) {
+      return;
+    }
+
+    auto button_event = event_queue::event(momentary_switch_event(pqrs::hid::usage_page::button,
+                                                                  *active_horizontal_wheel_button_));
+    output_event_queue->emplace_back_entry(front_input_event.get_device_id(),
+                                           front_input_event.get_event_time_stamp(),
+                                           button_event,
+                                           event_type::key_up,
+                                           event_integer_value::value_t(0),
+                                           button_event,
+                                           event_queue::state::manipulated);
+
+    active_horizontal_wheel_button_ = std::nullopt;
+  }
+
   bool flip_x_;
   bool flip_y_;
   bool flip_vertical_wheel_;
@@ -232,5 +337,8 @@ private:
   bool discard_y_;
   bool discard_vertical_wheel_;
   bool discard_horizontal_wheel_;
+  bool to_buttons_horizontal_wheel_;
+  bool enabled_;
+  std::optional<pqrs::hid::usage::value_t> active_horizontal_wheel_button_;
 };
 } // namespace krbn::manipulator::manipulators::mouse_basic

--- a/tests/src/manipulator_mouse_basic/src/reload_test.hpp
+++ b/tests/src/manipulator_mouse_basic/src/reload_test.hpp
@@ -1,0 +1,103 @@
+#include "../../../src/apps/CoreService/include/core_service/daemon/device_grabber_details/simple_modifications_manipulator_manager.hpp"
+#include "event_queue/utility.hpp"
+#include "manipulator/manipulator_managers_connector.hpp"
+#include <boost/ut.hpp>
+
+namespace {
+krbn::event_queue::not_null_entries_ptr_t make_horizontal_wheel_entries(
+    pqrs::not_null_shared_ptr_t<krbn::device_properties> device_properties,
+    int value,
+    krbn::absolute_time_point time_stamp) {
+  std::vector<pqrs::osx::iokit_hid_value> hid_values{
+      pqrs::osx::iokit_hid_value(time_stamp,
+                                 value,
+                                 pqrs::hid::usage_page::consumer,
+                                 pqrs::hid::usage::consumer::ac_pan,
+                                 std::nullopt,
+                                 std::nullopt),
+  };
+  return krbn::event_queue::utility::make_entries(device_properties,
+                                                  hid_values,
+                                                  {});
+}
+
+void manipulate(const krbn::event_queue::not_null_entries_ptr_t& entries,
+                const std::shared_ptr<krbn::event_queue::queue>& input_queue,
+                krbn::manipulator::manipulator_managers_connector& connector,
+                const std::shared_ptr<const krbn::core_configuration::core_configuration>& core_configuration) {
+  for (const auto& entry : *entries) {
+    input_queue->push_back_entry(*entry);
+    connector.manipulate(entry->get_event_time_stamp().get_time_stamp(),
+                         core_configuration);
+  }
+}
+
+std::vector<std::string> make_button_events(const krbn::event_queue::queue& queue) {
+  std::vector<std::string> result;
+  for (const auto& entry : queue.get_entries()) {
+    if (auto event = entry.get_event().get_if<krbn::momentary_switch_event>()) {
+      if (event->pointing_button()) {
+        auto name = krbn::momentary_switch_event_details::pointing_button::make_name(event->get_usage_pair().get_usage());
+        auto action = entry.get_event_type() == krbn::event_type::key_down ? "key_down" : "key_up";
+        result.push_back(name + " " + action);
+      }
+    }
+  }
+  return result;
+}
+} // namespace
+
+void run_reload_test() {
+  using namespace boost::ut;
+  using namespace boost::ut::literals;
+
+  "a held `to_buttons` press is released even when the manipulator is rebuilt mid-hold"_test = [] {
+    auto core_configuration = std::make_shared<krbn::core_configuration::core_configuration>();
+    auto device_properties = std::make_shared<krbn::device_properties>(
+        krbn::device_properties::initialization_parameters{
+            .device_id = krbn::device_id(1),
+            .vendor_id = pqrs::hid::vendor_id::value_t(0x1234),
+            .product_id = pqrs::hid::product_id::value_t(0x5678),
+            .is_pointing_device = true,
+        });
+    auto manager = std::make_shared<krbn::core_service::daemon::device_grabber_details::simple_modifications_manipulator_manager>();
+    auto input_queue = std::make_shared<krbn::event_queue::queue>();
+    auto output_queue = std::make_shared<krbn::event_queue::queue>();
+
+    krbn::manipulator::manipulator_managers_connector connector;
+    connector.emplace_back_connection(pqrs::make_weak(manager->get_manipulator_manager()),
+                                      input_queue,
+                                      output_queue);
+    connector.set_manipulator_environment_core_configuration(core_configuration);
+
+    output_queue->get_manipulator_environment().insert_device_properties(
+        device_properties->get_device_id(),
+        device_properties);
+
+    auto& profile = core_configuration->get_selected_profile();
+    auto device = profile.get_device(device_properties->get_device_identifiers());
+    device->set_mouse_horizontal_wheel_to_buttons(true);
+    manager->update(profile);
+
+    // Tilt left: button30 goes down.
+    manipulate(make_horizontal_wheel_entries(device_properties, -1, krbn::absolute_time_point(1)),
+              input_queue, connector, core_configuration);
+
+    // Any settings change rebuilds every manipulator (`invalidate_manipulators` followed by
+    // recreating them from the profile), even ones unrelated to this device or setting.
+    // The manipulator that pressed button30 above is superseded here, while the switch is
+    // still held.
+    manager->update(profile);
+
+    // The tilt is released. Without the fix, the superseded manipulator can no longer run
+    // (`validity_ == invalid`) and the fresh instance never learns that button30 was down,
+    // so button30 would stay stuck pressed forever.
+    manipulate(make_horizontal_wheel_entries(device_properties, 0, krbn::absolute_time_point(2)),
+              input_queue, connector, core_configuration);
+
+    expect(make_button_events(*output_queue) == std::vector<std::string>{
+                                                     "button30 key_down",
+                                                     "button30 key_up",
+                                                 });
+  };
+}

--- a/tests/src/manipulator_mouse_basic/src/test.cpp
+++ b/tests/src/manipulator_mouse_basic/src/test.cpp
@@ -1,6 +1,8 @@
 #include "errors_test.hpp"
+#include "reload_test.hpp"
 
 int main() {
   run_errors_test();
+  run_reload_test();
   return 0;
 }

--- a/tests/src/post_event_to_virtual_devices/json/expected_post_event_to_virtual_devices_queue/mouse_basic_to_buttons.json
+++ b/tests/src/post_event_to_virtual_devices/json/expected_post_event_to_virtual_devices_queue/mouse_basic_to_buttons.json
@@ -1,0 +1,97 @@
+[
+    {
+        "pointing_input": {
+            "buttons": [],
+            "horizontal_wheel": 0,
+            "vertical_wheel": 0,
+            "x": 3,
+            "y": 4
+        },
+        "time_stamp": 2,
+        "type": "pointing_input"
+    },
+    {
+        "keyboard_input": {
+            "keys": [
+                {
+                    "key_code": "a"
+                }
+            ],
+            "modifiers": []
+        },
+        "time_stamp": 7,
+        "type": "keyboard_input"
+    },
+    {
+        "pointing_input": {
+            "buttons": [],
+            "horizontal_wheel": 0,
+            "vertical_wheel": 0,
+            "x": 0,
+            "y": 0
+        },
+        "time_stamp": 100002,
+        "type": "pointing_input"
+    },
+    {
+        "pointing_input": {
+            "buttons": [],
+            "horizontal_wheel": 0,
+            "vertical_wheel": 0,
+            "x": 0,
+            "y": 0
+        },
+        "time_stamp": 200002,
+        "type": "pointing_input"
+    },
+    {
+        "pointing_input": {
+            "buttons": [],
+            "horizontal_wheel": 0,
+            "vertical_wheel": 0,
+            "x": 5,
+            "y": 6
+        },
+        "time_stamp": 300002,
+        "type": "pointing_input"
+    },
+    {
+        "keyboard_input": {
+            "keys": [],
+            "modifiers": []
+        },
+        "time_stamp": 300007,
+        "type": "keyboard_input"
+    },
+    {
+        "keyboard_input": {
+            "keys": [
+                {
+                    "key_code": "b"
+                }
+            ],
+            "modifiers": []
+        },
+        "time_stamp": 300012,
+        "type": "keyboard_input"
+    },
+    {
+        "pointing_input": {
+            "buttons": [],
+            "horizontal_wheel": 0,
+            "vertical_wheel": 0,
+            "x": 0,
+            "y": 0
+        },
+        "time_stamp": 1000000,
+        "type": "pointing_input"
+    },
+    {
+        "keyboard_input": {
+            "keys": [],
+            "modifiers": []
+        },
+        "time_stamp": 1000005,
+        "type": "keyboard_input"
+    }
+]

--- a/tests/src/post_event_to_virtual_devices/json/input_event_queue/mouse_basic_to_buttons.jsonc
+++ b/tests/src/post_event_to_virtual_devices/json/input_event_queue/mouse_basic_to_buttons.jsonc
@@ -1,0 +1,141 @@
+[
+    // Tilt left, held for three repeated reports (some devices repeat the value while the switch is held).
+    {
+        "device_id": 1,
+        "event": {
+            "pointing_motion": {
+                "horizontal_wheel": -1,
+                "vertical_wheel": 0,
+                "x": 3,
+                "y": 4
+            },
+            "type": "pointing_motion"
+        },
+        "event_time_stamp": {
+            "time_stamp": 2
+        },
+        "event_type": "single",
+        "lazy": false,
+        "original_event": {
+            "pointing_motion": {
+                "horizontal_wheel": -1,
+                "vertical_wheel": 0,
+                "x": 3,
+                "y": 4
+            },
+            "type": "pointing_motion"
+        },
+        "validity": true
+    },
+    {
+        "device_id": 1,
+        "event": {
+            "pointing_motion": {
+                "horizontal_wheel": -1,
+                "vertical_wheel": 0,
+                "x": 0,
+                "y": 0
+            },
+            "type": "pointing_motion"
+        },
+        "event_time_stamp": {
+            "time_stamp": 100002
+        },
+        "event_type": "single",
+        "lazy": false,
+        "original_event": {
+            "pointing_motion": {
+                "horizontal_wheel": -1,
+                "vertical_wheel": 0,
+                "x": 0,
+                "y": 0
+            },
+            "type": "pointing_motion"
+        },
+        "validity": true
+    },
+    {
+        "device_id": 1,
+        "event": {
+            "pointing_motion": {
+                "horizontal_wheel": -1,
+                "vertical_wheel": 0,
+                "x": 0,
+                "y": 0
+            },
+            "type": "pointing_motion"
+        },
+        "event_time_stamp": {
+            "time_stamp": 200002
+        },
+        "event_type": "single",
+        "lazy": false,
+        "original_event": {
+            "pointing_motion": {
+                "horizontal_wheel": -1,
+                "vertical_wheel": 0,
+                "x": 0,
+                "y": 0
+            },
+            "type": "pointing_motion"
+        },
+        "validity": true
+    },
+    // Tilt right directly, without an intervening zero report, to exercise a same-tick
+    // key_up(button30) + key_down(button31) pair.
+    {
+        "device_id": 1,
+        "event": {
+            "pointing_motion": {
+                "horizontal_wheel": 1,
+                "vertical_wheel": 0,
+                "x": 5,
+                "y": 6
+            },
+            "type": "pointing_motion"
+        },
+        "event_time_stamp": {
+            "time_stamp": 300002
+        },
+        "event_type": "single",
+        "lazy": false,
+        "original_event": {
+            "pointing_motion": {
+                "horizontal_wheel": 1,
+                "vertical_wheel": 0,
+                "x": 5,
+                "y": 6
+            },
+            "type": "pointing_motion"
+        },
+        "validity": true
+    },
+    // Released.
+    {
+        "device_id": 1,
+        "event": {
+            "pointing_motion": {
+                "horizontal_wheel": 0,
+                "vertical_wheel": 0,
+                "x": 0,
+                "y": 0
+            },
+            "type": "pointing_motion"
+        },
+        "event_time_stamp": {
+            "time_stamp": 1000000
+        },
+        "event_type": "single",
+        "lazy": false,
+        "original_event": {
+            "pointing_motion": {
+                "horizontal_wheel": 0,
+                "vertical_wheel": 0,
+                "x": 0,
+                "y": 0
+            },
+            "type": "pointing_motion"
+        },
+        "validity": true
+    }
+]

--- a/tests/src/post_event_to_virtual_devices/json/rules/mouse_basic_to_buttons.jsonc
+++ b/tests/src/post_event_to_virtual_devices/json/rules/mouse_basic_to_buttons.jsonc
@@ -1,0 +1,7 @@
+[
+    {
+        "description": "convert horizontal wheel to buttons",
+        "type": "mouse_basic",
+        "to_buttons": ["horizontal_wheel"]
+    }
+]

--- a/tests/src/post_event_to_virtual_devices/json/rules/mouse_basic_to_buttons_remap.jsonc
+++ b/tests/src/post_event_to_virtual_devices/json/rules/mouse_basic_to_buttons_remap.jsonc
@@ -1,0 +1,14 @@
+[
+    {
+        "description": "button30 to a",
+        "type": "basic",
+        "from": { "pointing_button": "button30" },
+        "to": [{ "key_code": "a" }]
+    },
+    {
+        "description": "button31 to b",
+        "type": "basic",
+        "from": { "pointing_button": "button31" },
+        "to": [{ "key_code": "b" }]
+    }
+]

--- a/tests/src/post_event_to_virtual_devices/json/tests.json
+++ b/tests/src/post_event_to_virtual_devices/json/tests.json
@@ -900,6 +900,15 @@
         "expected_post_event_to_virtual_devices_queue": "json/expected_post_event_to_virtual_devices_queue/mouse_basic_1.json"
     },
     {
+        "description": "mouse_basic_to_buttons",
+        "rules": [
+            "json/rules/mouse_basic_to_buttons.jsonc",
+            "json/rules/mouse_basic_to_buttons_remap.jsonc"
+        ],
+        "input_event_queue": "json/input_event_queue/mouse_basic_to_buttons.jsonc",
+        "expected_post_event_to_virtual_devices_queue": "json/expected_post_event_to_virtual_devices_queue/mouse_basic_to_buttons.json"
+    },
+    {
         "description": "specify modifiers order",
         "rules": ["json/rules/vk_none.jsonc"],
         "input_event_queue": "json/input_event_queue/vk_none_1.jsonc",


### PR DESCRIPTION
Add a mouse setting to turn the wheel tilt into buttons, so that they can be remapped 

<img width="289" height="75" alt="Screenshot 2026-09-09 at 15 12 32" src="https://github.com/user-attachments/assets/2d17b15e-724c-42c1-a64d-b5cb22d8c6ab" />
